### PR TITLE
Pass comments to CDC events

### DIFF
--- a/src/postgres/src/backend/catalog/yb_catalog/yb_catalog_version.c
+++ b/src/postgres/src/backend/catalog/yb_catalog/yb_catalog_version.c
@@ -543,7 +543,8 @@ YbIncrementMasterDBCatalogVersionTableEntryImpl(Oid db_oid,
 								  YBCatalogVersionRelationId,
 								  false /* is_region_local */ ,
 								  &update_stmt,
-								  YB_TRANSACTIONAL));
+								  YB_TRANSACTIONAL,
+								  NULL /* query_comment */));
 
 	Relation	rel = RelationIdGetRelation(YBCatalogVersionRelationId);
 	Datum		ybctid = YbGetMasterCatalogVersionTableEntryYbctid(rel, db_oid);
@@ -727,7 +728,8 @@ YbCreateMasterDBCatalogVersionTableEntry(Oid db_oid)
 								  YBCatalogVersionRelationId,
 								  false /* is_region_local */ ,
 								  &insert_stmt,
-								  YB_SINGLE_SHARD_TRANSACTION));
+								  YB_SINGLE_SHARD_TRANSACTION,
+								  NULL /* query_comment */));
 
 	Relation	rel = RelationIdGetRelation(YBCatalogVersionRelationId);
 	Datum		ybctid = YbGetMasterCatalogVersionTableEntryYbctid(rel, db_oid);
@@ -833,7 +835,8 @@ YbDeleteMasterDBCatalogVersionTableEntry(Oid db_oid)
 								  YBCatalogVersionRelationId,
 								  false /* is_region_local */ ,
 								  &delete_stmt,
-								  YB_SINGLE_SHARD_TRANSACTION));
+								  YB_SINGLE_SHARD_TRANSACTION,
+								  NULL /* query_comment */));
 
 	Relation	rel = RelationIdGetRelation(YBCatalogVersionRelationId);
 	Datum		ybctid = YbGetMasterCatalogVersionTableEntryYbctid(rel, db_oid);

--- a/src/postgres/src/backend/catalog/yb_logical_client/yb_logical_client_version.c
+++ b/src/postgres/src/backend/catalog/yb_logical_client/yb_logical_client_version.c
@@ -157,7 +157,8 @@ YbIncrementMasterDBLogicalClientVersionTableEntryImpl(Oid db_oid)
 								  YBLogicalClientVersionRelationId,
 								  false /* is_region_local */ ,
 								  &update_stmt,
-								  YB_TRANSACTIONAL));
+								  YB_TRANSACTIONAL,
+								  NULL /* query_comment */));
 
 	Relation	rel = RelationIdGetRelation(YBLogicalClientVersionRelationId);
 	Datum		ybctid = YbGetMasterLogicalClientVersionTableEntryYbctid(rel, db_oid);
@@ -264,7 +265,8 @@ YbCreateMasterDBLogicalClientVersionTableEntry(Oid db_oid)
 								  YBLogicalClientVersionRelationId,
 								  false /* is_region_local */ ,
 								  &insert_stmt,
-								  YB_SINGLE_SHARD_TRANSACTION));
+								  YB_SINGLE_SHARD_TRANSACTION,
+								  NULL /* query_comment */));
 
 	Relation	rel = RelationIdGetRelation(YBLogicalClientVersionRelationId);
 	Datum		ybctid = YbGetMasterLogicalClientVersionTableEntryYbctid(rel, db_oid);
@@ -317,7 +319,8 @@ YbDeleteMasterDBLogicalClientVersionTableEntry(Oid db_oid)
 								  YBLogicalClientVersionRelationId,
 								  false /* is_region_local */ ,
 								  &delete_stmt,
-								  YB_SINGLE_SHARD_TRANSACTION));
+								  YB_SINGLE_SHARD_TRANSACTION,
+								  NULL /* query_comment */));
 
 	Relation	rel = RelationIdGetRelation(YBLogicalClientVersionRelationId);
 	Datum		ybctid = YbGetMasterLogicalClientVersionTableEntryYbctid(rel, db_oid);

--- a/src/postgres/src/backend/executor/ybModifyTable.c
+++ b/src/postgres/src/backend/executor/ybModifyTable.c
@@ -57,6 +57,7 @@
 #include "nodes/execnodes.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/ybplan.h"
+#include "parser/parser.h"
 #include "pg_yb_utils.h"
 #include "tcop/pquery.h"
 #include "utils/builtins.h"
@@ -420,13 +421,18 @@ YBCExecuteInsertInternal(Oid dboid,
 {
 	Oid			relfileNodeId = YbGetRelfileNodeId(rel);
 	YbcPgStatement insert_stmt = NULL;
+	char	   *query_comment = NULL;
+
+	/* Extract SQL comment for CDC tracking */
+	query_comment = extract_first_sql_comment(debug_query_string);
 
 	/* Create the INSERT request and add the values from the tuple. */
 	HandleYBStatus(YBCPgNewInsert(dboid,
 								  relfileNodeId,
 								  YBCIsRegionLocal(rel),
 								  &insert_stmt,
-								  transaction_setting));
+								  transaction_setting,
+								  query_comment));
 
 	YBCApplyInsertRow(insert_stmt, rel, slot, onConflictAction, ybctid,
 					  transaction_setting);
@@ -779,7 +785,8 @@ YBCExecuteInsertIndexForDb(Oid dboid,
 								  YBCIsRegionLocal(index), &insert_stmt,
 								  (is_non_distributed_txn_write ?
 								   YB_NON_TRANSACTIONAL :
-								   YB_TRANSACTIONAL)));
+								   YB_TRANSACTIONAL),
+								  NULL /* query_comment */));
 
 	callback(insert_stmt, indexstate, index, values, isnull,
 			 RelationGetNumberOfAttributes(index),
@@ -824,16 +831,21 @@ YBCExecuteDelete(Relation rel,
 	YbcPgStatement delete_stmt = NULL;
 	Datum		ybctid;
 	Oid			relfileNodeId = YbGetRelfileNodeId(rel);
+	char	   *query_comment = NULL;
 
 	/* YB_SINGLE_SHARD_TRANSACTION always implies target tuple wasn't fetched. */
 	Assert((transaction_setting != YB_SINGLE_SHARD_TRANSACTION) || !target_tuple_fetched);
+
+	/* Extract SQL comment for CDC tracking */
+	query_comment = extract_first_sql_comment(debug_query_string);
 
 	/* Create DELETE request. */
 	HandleYBStatus(YBCPgNewDelete(dboid,
 								  relfileNodeId,
 								  YBCIsRegionLocal(rel),
 								  &delete_stmt,
-								  transaction_setting));
+								  transaction_setting,
+								  query_comment));
 
 	/*
 	 * Look for ybctid. Raise error if ybctid is not found.
@@ -1004,7 +1016,8 @@ YBCExecuteDeleteIndex(Relation index,
 								  YbGetRelfileNodeId(index),
 								  YBCIsRegionLocal(index),
 								  &delete_stmt,
-								  YB_TRANSACTIONAL));
+								  YB_TRANSACTIONAL,
+								  NULL /* query_comment */));
 
 	callback(delete_stmt, indexstate, index, values, isnull,
 			 IndexRelationGetNumberOfKeyAttributes(index),
@@ -1050,6 +1063,7 @@ YBCExecuteUpdate(ResultRelInfo *resultRelInfo,
 	Oid			relid = RelationGetRelid(rel);
 	YbcPgStatement update_stmt = NULL;
 	Datum		ybctid;
+	char	   *query_comment = NULL;
 
 
 	/* YB_SINGLE_SHARD_TRANSACTION always implies target tuple wasn't fetched. */
@@ -1058,12 +1072,16 @@ YBCExecuteUpdate(ResultRelInfo *resultRelInfo,
 	/* Update the tuple with table oid */
 	slot->tts_tableOid = RelationGetRelid(rel);
 
+	/* Extract SQL comment for CDC tracking */
+	query_comment = extract_first_sql_comment(debug_query_string);
+
 	/* Create update statement. */
 	HandleYBStatus(YBCPgNewUpdate(dboid,
 								  YbGetRelfileNodeId(rel),
 								  YBCIsRegionLocal(rel),
 								  &update_stmt,
-								  transaction_setting));
+								  transaction_setting,
+								  query_comment));
 
 	/*
 	 * Look for ybctid. Raise error if ybctid is not found.
@@ -1325,7 +1343,8 @@ YBCExecuteUpdateIndex(Relation index,
 								  YbGetRelfileNodeId(index),
 								  YBCIsRegionLocal(index),
 								  &update_stmt,
-								  YB_TRANSACTIONAL));
+								  YB_TRANSACTIONAL,
+								  NULL /* query_comment */));
 
 	callback(update_stmt, index, values, isnull,
 			 RelationGetNumberOfAttributes(index),
@@ -1353,7 +1372,8 @@ YBCExecuteUpdateLoginAttempts(Oid roleid,
 								  YbRoleProfileRelationId,
 								  YBCIsRegionLocal(rel),
 								  &update_stmt,
-								  YB_SINGLE_SHARD_TRANSACTION));
+								  YB_SINGLE_SHARD_TRANSACTION,
+								  NULL /* query_comment */));
 
 	/*
 	 * Look for ybctid. Raise error if ybctid is not found.
@@ -1449,7 +1469,8 @@ YBCDeleteSysCatalogTuple(Relation rel, HeapTuple tuple)
 								  relfileNodeId,
 								  YBCIsRegionLocal(rel),
 								  &delete_stmt,
-								  YB_TRANSACTIONAL));
+								  YB_TRANSACTIONAL,
+								  NULL /* query_comment */));
 
 	/* Bind ybctid to identify the current row. */
 	YbcPgExpr	ybctid_expr = YBCNewConstant(delete_stmt, BYTEAOID, InvalidOid,
@@ -1492,7 +1513,8 @@ YBCUpdateSysCatalogTupleForDb(Oid dboid, Relation rel, HeapTuple oldtuple,
 								  relid,
 								  YBCIsRegionLocal(rel),
 								  &update_stmt,
-								  YB_TRANSACTIONAL));
+								  YB_TRANSACTIONAL,
+								  NULL /* query_comment */));
 
 	AttrNumber	minattr = YBGetFirstLowInvalidAttributeNumber(rel);
 	Bitmapset  *pkey = YBGetTablePrimaryKeyBms(rel);

--- a/src/postgres/src/backend/parser/parser.c
+++ b/src/postgres/src/backend/parser/parser.c
@@ -499,3 +499,59 @@ invalid_pair:
 								 yyscanner)));
 	return NULL;				/* keep compiler quiet */
 }
+
+/*
+ * extract_first_sql_comment
+ *     Extract the first C-style block comment from a SQL query string
+ *     Returns palloc'd string with comment content (without delimiters), or NULL
+ */
+char *
+extract_first_sql_comment(const char *query_string)
+{
+	const char *start;
+	const char *end;
+	int			len;
+	char	   *comment;
+	char	   *p;
+
+	if (!query_string)
+		return NULL;
+
+	/* Find start of comment */
+	start = strstr(query_string, "/*");
+	if (!start)
+		return NULL;
+
+	/* Find end of comment */
+	end = strstr(start + 2, "*/");
+	if (!end)
+		return NULL;
+
+	/* Extract content between comment delimiters */
+	len = end - (start + 2);
+	if (len <= 0)
+		return NULL;
+
+	comment = palloc(len + 1);
+	memcpy(comment, start + 2, len);
+	comment[len] = '\0';
+
+	/* Trim leading/trailing whitespace */
+	p = comment;
+	while (*p && isspace((unsigned char) *p))
+		p++;
+
+	if (*p == '\0')
+	{
+		pfree(comment);
+		return NULL;
+	}
+
+	/* Trim trailing */
+	len = strlen(p);
+	while (len > 0 && isspace((unsigned char) p[len - 1]))
+		len--;
+	p[len] = '\0';
+
+	return p == comment ? comment : pstrdup(p);
+}

--- a/src/postgres/src/include/parser/parser.h
+++ b/src/postgres/src/include/parser/parser.h
@@ -65,4 +65,7 @@ extern List *raw_parser(const char *str, RawParseMode mode);
 extern List *SystemFuncName(char *name);
 extern TypeName *SystemTypeName(char *name);
 
+/* Extract SQL comment for CDC tracking */
+extern char *extract_first_sql_comment(const char *query_string);
+
 #endif							/* PARSER_H */

--- a/src/yb/cdc/cdc_service.proto
+++ b/src/yb/cdc/cdc_service.proto
@@ -553,6 +553,10 @@ message RowMessage {
   // DocKey for the row in a table. Only populated for DMLs in the streaming phase but not
   // for other ops such as DDL/BEGIN/COMMIT/SAFEPOINT. Not populated in the Snapshot phase.
   optional bytes primary_key = 18;
+
+  // SQL comment extracted from query (/* comment */)
+  // Enables correlation across multi-shard transactions
+  optional string query_comment = 19;
 }
 
 message CDCSDKProtoRecordPB {

--- a/src/yb/cdc/cdcsdk_producer.cc
+++ b/src/yb/cdc/cdcsdk_producer.cc
@@ -1426,6 +1426,12 @@ Status PopulateCDCSDKWriteRecord(
       row_message->set_primary_key(primary_key.ToBuffer());
       CDCSDKOpIdPB* cdc_sdk_op_id_pb = proto_record->mutable_cdc_sdk_op_id();
       SetCDCSDKOpId(msg->id().term(), msg->id().index(), record_batch_idx, "", cdc_sdk_op_id_pb);
+
+      // Add query comment if present
+      if (msg->has_write() && msg->write().has_query_comment()) {
+        row_message->set_query_comment(msg->write().query_comment().ToBuffer());
+      }
+
       is_packed_row_record = false;
 
       // Check whether operation is WRITE or DELETE.
@@ -1650,6 +1656,12 @@ Status PopulateCDCSDKDDLRecord(
   row_message->set_pgschema_name(schema.SchemaName());
   row_message->set_commit_time(msg->hybrid_time());
   SetTableProperties(table_properties->ToGoogleProtobuf(), cdc_sdk_table_properties_pb);
+
+  // Add query comment for DDL if present
+  if (msg->has_change_metadata_request() &&
+      msg->change_metadata_request().has_query_comment()) {
+    row_message->set_query_comment(msg->change_metadata_request().query_comment().ToBuffer());
+  }
 
   throughput_metrics->records_sent++;
   throughput_metrics->bytes_sent += proto_record->ByteSizeLong();

--- a/src/yb/common/pgsql_protocol.proto
+++ b/src/yb/common/pgsql_protocol.proto
@@ -319,6 +319,9 @@ message PgsqlWriteRequestPB {
   // What metric changes to return in response.
   optional PgsqlMetricsCaptureType metrics_capture = 28;
 
+  // SQL comment from query for CDC tracking
+  optional string query_comment = 30;
+
   // Table space oid of the table specified by table_id.
   optional uint32 tablespace_oid = 29;
 }

--- a/src/yb/tablet/operations.proto
+++ b/src/yb/tablet/operations.proto
@@ -101,6 +101,9 @@ message WritePB {
   optional uint64 batch_idx = 20;
 
   optional uint64 start_time_micros = 21;
+
+  // SQL comment for CDC tracking
+  optional string query_comment = 22;
 }
 
 message ChangeMetadataRequestPB {
@@ -158,6 +161,9 @@ message ChangeMetadataRequestPB {
   //
   // If missing, then all existing columns may safely be treated as non-provisional.
   optional int32 first_provisional_column_id = 21;
+
+  // SQL comment from DDL statement
+  optional string query_comment = 22;
 }
 
 message SplitTabletRequestPB {

--- a/src/yb/tablet/write_query.cc
+++ b/src/yb/tablet/write_query.cc
@@ -121,6 +121,13 @@ void SetupKeyValueBatch(const tserver::WriteRequestPB& client_request, LWWritePB
   if (client_request.has_external_hybrid_time()) {
     out_request->set_external_hybrid_time(client_request.external_hybrid_time());
   }
+  // Copy query_comment from first PgsqlWriteRequestPB that has one
+  for (const auto& pgsql_req : client_request.pgsql_write_batch()) {
+    if (pgsql_req.has_query_comment()) {
+      out_request->dup_query_comment(pgsql_req.query_comment());
+      break;
+    }
+  }
 }
 
 template <class Code, class Resp>

--- a/src/yb/yql/pggate/pg_dml_write.cc
+++ b/src/yb/yql/pggate/pg_dml_write.cc
@@ -121,6 +121,11 @@ Status PgDmlWrite::Exec(ForceNonBufferable force_non_bufferable) {
   // First update protobuf with new bind values.
   RETURN_NOT_OK(UpdateAssignPBs());
 
+  // Add query comment to write request for CDC
+  if (!query_comment_.empty()) {
+    write_req_->dup_query_comment(query_comment_);
+  }
+
   if (write_req_->has_ybctid_column_value()) {
     auto* exprpb = write_req_->mutable_ybctid_column_value();
     CHECK(exprpb->has_value() && exprpb->value().has_binary_value())

--- a/src/yb/yql/pggate/pg_dml_write.h
+++ b/src/yb/yql/pggate/pg_dml_write.h
@@ -46,6 +46,11 @@ class PgDmlWrite : public PgDml {
 
   Status SetWriteTime(const HybridTime& write_time);
 
+  // Set SQL query comment for CDC tracking
+  void SetQueryComment(const std::string& comment) {
+    query_comment_ = comment;
+  }
+
   Status BindRow(uint64_t ybctid, YbcBindColumn* columns, int count);
 
   [[nodiscard]] bool packed() const { return packed_; }
@@ -75,6 +80,8 @@ class PgDmlWrite : public PgDml {
   int32_t rows_affected_count_ = 0;
 
   bool packed_;
+
+  std::string query_comment_;
 
  private:
   [[nodiscard]] ArenaList<LWPgsqlColRefPB>& ColRefPBs() override;

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -1522,12 +1522,17 @@ Result<PgStatement*> PgApiImpl::NewInsertBlock(
 
 Status PgApiImpl::NewInsert(
     const PgObjectId& table_id, bool is_region_local, PgStatement **handle,
-    YbcPgTransactionSetting transaction_setting) {
+    YbcPgTransactionSetting transaction_setting, const char *query_comment) {
   *handle = nullptr;
-  return AddToCurrentPgMemctx(
-    VERIFY_RESULT(PgInsert::Make(
-        pg_session_, table_id, is_region_local, transaction_setting, /* packed= */ false)),
-    handle);
+  auto insert = VERIFY_RESULT(PgInsert::Make(
+      pg_session_, table_id, is_region_local, transaction_setting, /* packed= */ false));
+
+  // Set query comment if provided
+  if (query_comment) {
+    insert->SetQueryComment(query_comment);
+  }
+
+  return AddToCurrentPgMemctx(std::move(insert), handle);
 }
 
 Status PgApiImpl::ExecInsert(PgStatement* handle) {
@@ -1552,11 +1557,17 @@ Status PgApiImpl::InsertStmtSetIsBackfill(PgStatement* handle, bool is_backfill)
 
 Status PgApiImpl::NewUpdate(
     const PgObjectId& table_id, bool is_region_local, PgStatement** handle,
-    YbcPgTransactionSetting transaction_setting) {
+    YbcPgTransactionSetting transaction_setting, const char *query_comment) {
   *handle = nullptr;
-  return AddToCurrentPgMemctx(
-      VERIFY_RESULT(PgUpdate::Make(pg_session_, table_id, is_region_local, transaction_setting)),
-      handle);
+  auto update = VERIFY_RESULT(PgUpdate::Make(
+      pg_session_, table_id, is_region_local, transaction_setting));
+
+  // Set query comment if provided
+  if (query_comment) {
+    update->SetQueryComment(query_comment);
+  }
+
+  return AddToCurrentPgMemctx(std::move(update), handle);
 }
 
 Status PgApiImpl::ExecUpdate(PgStatement* handle) {
@@ -1567,11 +1578,17 @@ Status PgApiImpl::ExecUpdate(PgStatement* handle) {
 
 Status PgApiImpl::NewDelete(
     const PgObjectId& table_id, bool is_region_local, PgStatement** handle,
-    YbcPgTransactionSetting transaction_setting) {
+    YbcPgTransactionSetting transaction_setting, const char *query_comment) {
   *handle = nullptr;
-  return AddToCurrentPgMemctx(
-      VERIFY_RESULT(PgDelete::Make(pg_session_, table_id, is_region_local, transaction_setting)),
-      handle);
+  auto delete_stmt = VERIFY_RESULT(PgDelete::Make(
+      pg_session_, table_id, is_region_local, transaction_setting));
+
+  // Set query comment if provided
+  if (query_comment) {
+    delete_stmt->SetQueryComment(query_comment);
+  }
+
+  return AddToCurrentPgMemctx(std::move(delete_stmt), handle);
 }
 
 Status PgApiImpl::ExecDelete(PgStatement* handle) {

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -563,7 +563,8 @@ class PgApiImpl {
                    bool is_region_local,
                    PgStatement **handle,
                    YbcPgTransactionSetting transaction_setting =
-                       YbcPgTransactionSetting::YB_TRANSACTIONAL);
+                       YbcPgTransactionSetting::YB_TRANSACTIONAL,
+                   const char *query_comment = nullptr);
 
   Status ExecInsert(PgStatement *handle);
 
@@ -579,7 +580,8 @@ class PgApiImpl {
                    bool is_region_local,
                    PgStatement **handle,
                    YbcPgTransactionSetting transaction_setting =
-                       YbcPgTransactionSetting::YB_TRANSACTIONAL);
+                       YbcPgTransactionSetting::YB_TRANSACTIONAL,
+                   const char *query_comment = nullptr);
 
   Status ExecUpdate(PgStatement *handle);
 
@@ -589,7 +591,8 @@ class PgApiImpl {
                    bool is_region_local,
                    PgStatement **handle,
                    YbcPgTransactionSetting transaction_setting =
-                       YbcPgTransactionSetting::YB_TRANSACTIONAL);
+                       YbcPgTransactionSetting::YB_TRANSACTIONAL,
+                   const char *query_comment = nullptr);
 
   Status ExecDelete(PgStatement *handle);
 

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1599,9 +1599,10 @@ YbcStatus YBCPgNewInsert(const YbcPgOid database_oid,
                          const YbcPgOid table_relfilenode_oid,
                          bool is_region_local,
                          YbcPgStatement *handle,
-                         YbcPgTransactionSetting transaction_setting) {
+                         YbcPgTransactionSetting transaction_setting,
+                         const char *query_comment) {
   const PgObjectId table_id(database_oid, table_relfilenode_oid);
-  return ToYBCStatus(pgapi->NewInsert(table_id, is_region_local, handle, transaction_setting));
+  return ToYBCStatus(pgapi->NewInsert(table_id, is_region_local, handle, transaction_setting, query_comment));
 }
 
 YbcStatus YBCPgExecInsert(YbcPgStatement handle) {
@@ -1631,9 +1632,10 @@ YbcStatus YBCPgNewUpdate(const YbcPgOid database_oid,
                          const YbcPgOid table_relfilenode_oid,
                          bool is_region_local,
                          YbcPgStatement *handle,
-                         YbcPgTransactionSetting transaction_setting) {
+                         YbcPgTransactionSetting transaction_setting,
+                         const char *query_comment) {
   const PgObjectId table_id(database_oid, table_relfilenode_oid);
-  return ToYBCStatus(pgapi->NewUpdate(table_id, is_region_local, handle, transaction_setting));
+  return ToYBCStatus(pgapi->NewUpdate(table_id, is_region_local, handle, transaction_setting, query_comment));
 }
 
 YbcStatus YBCPgExecUpdate(YbcPgStatement handle) {
@@ -1645,9 +1647,10 @@ YbcStatus YBCPgNewDelete(const YbcPgOid database_oid,
                          const YbcPgOid table_relfilenode_oid,
                          bool is_region_local,
                          YbcPgStatement *handle,
-                         YbcPgTransactionSetting transaction_setting) {
+                         YbcPgTransactionSetting transaction_setting,
+                         const char *query_comment) {
   const PgObjectId table_id(database_oid, table_relfilenode_oid);
-  return ToYBCStatus(pgapi->NewDelete(table_id, is_region_local, handle, transaction_setting));
+  return ToYBCStatus(pgapi->NewDelete(table_id, is_region_local, handle, transaction_setting, query_comment));
 }
 
 YbcStatus YBCPgExecDelete(YbcPgStatement handle) {

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -648,7 +648,8 @@ YbcStatus YBCPgNewInsert(YbcPgOid database_oid,
                          YbcPgOid table_relfilenode_oid,
                          bool is_region_local,
                          YbcPgStatement *handle,
-                         YbcPgTransactionSetting transaction_setting);
+                         YbcPgTransactionSetting transaction_setting,
+                         const char *query_comment);
 
 YbcStatus YBCPgExecInsert(YbcPgStatement handle);
 
@@ -663,7 +664,8 @@ YbcStatus YBCPgNewUpdate(YbcPgOid database_oid,
                          YbcPgOid table_relfilenode_oid,
                          bool is_region_local,
                          YbcPgStatement *handle,
-                         YbcPgTransactionSetting transaction_setting);
+                         YbcPgTransactionSetting transaction_setting,
+                         const char *query_comment);
 
 YbcStatus YBCPgExecUpdate(YbcPgStatement handle);
 
@@ -672,7 +674,8 @@ YbcStatus YBCPgNewDelete(YbcPgOid database_oid,
                          YbcPgOid table_relfilenode_oid,
                          bool is_region_local,
                          YbcPgStatement *handle,
-                         YbcPgTransactionSetting transaction_setting);
+                         YbcPgTransactionSetting transaction_setting,
+                         const char *query_comment);
 
 YbcStatus YBCPgExecDelete(YbcPgStatement handle);
 


### PR DESCRIPTION
# Add SQL Comment Support to CDC (CDCSDK)

## Problem

During database migration with bidirectional replication, starting reverse replication before cutover causes replication loops. Backfilter can use sql comments to filter out events that originated from the forward replication stream. Alternative option is to start reverse replication DURING the cutover, which affects the cutover duration.      

## Solution

Extract SQL comments (`/* */`) from queries and propagate them through CDC events. Replication consumers can mark their writes with comments and filter them out on the reverse stream.

**Example:**
```sql
-- Forward replication writes with marker
/* application=backfilter */
INSERT INTO orders (id, customer_id) VALUES (1, 100);

-- Reverse replication filters events with query_comment="application=backfilter"
```

## Changes

Added `query_comment` field (optional string) to 4 protobuf messages:
- `RowMessage` (field 19) - CDC output
- `PgsqlWriteRequestPB` (field 30) - YSQL write request
- `WritePB` (field 22) - Raft log entry
- `ChangeMetadataRequestPB` (field 22) - DDL operations

Implemented comment extraction in PostgreSQL parser (`extract_first_sql_comment()`) and threaded through YSQL → PgGate → Tablet → CDC Producer layers.

## Key Design Decisions

- **Comment-only**: Small overhead (~50-200 bytes), no privacy concerns, user-controlled metadata
- **CDCSDK only**: Not implemented for XCLUSTER/2DC
- **First comment only**: Extracts first `/* */` block comment for simplicity
- **Optional field**: Zero overhead when not used

## Breaking Changes

None - backward-compatible additive change. Existing CDC consumers ignore unknown fields.

## Files Changed

Key files:
- `src/yb/cdc/cdc_service.proto` - CDC output schema
- `src/postgres/src/backend/parser/parser.c` - Comment extraction
- `src/postgres/src/backend/executor/ybModifyTable.c` - YSQL integration
- `src/yb/yql/pggate/*` - PgGate threading
- `src/yb/tablet/write_query.cc` - Tablet propagation
- `src/yb/cdc/cdcsdk_producer.cc` - CDC producer population

Tested custom build on the test cluster: 

```
  4:31PM INF Record from tablet commit_time=7250832059633831936 hybrid_time="2026-02-04 16:31:10.809 [logical=0]" id=1102 op=INSERT query_comment=my_comment:1234567890 record_num=5 table=test                                          
  tablet_id=49b74a7a5525471f88b08c1039bab0f7 transaction_id=0      
```
