### PR TITLE
[CDC] DocDB: Per-phase latency and batch-size metrics for CDCSDK GetChanges

### DIFF
--- a/src/yb/cdc/cdc_producer.h
+++ b/src/yb/cdc/cdc_producer.h
@@ -34,6 +34,10 @@ namespace yb {
 
 class MemTracker;
 
+namespace xrepl {
+class CDCSDKTabletMetrics;
+}  // namespace xrepl
+
 namespace cdc {
 
 struct SchemaDetails {
@@ -49,6 +53,14 @@ using consensus::HaveMoreMessages;
 struct CDCThroughputMetrics {
   uint64_t records_sent = 0;
   uint64_t bytes_sent = 0;
+  // Per-tablet metrics for the CDCSDK stream/tablet pair. Non-owning. Null on the xCluster
+  // path or when metrics could not be acquired; observation sites must null-check before use
+  // (ScopedLatencyMetric handles this automatically).
+  xrepl::CDCSDKTabletMetrics* tablet_metrics = nullptr;
+  // Per-call accumulators populated inside the producer and emitted as histograms by the
+  // service layer at the end of the RPC.
+  uint64_t wal_records_read = 0;
+  uint64_t wal_bytes_read = 0;
 };
 
 using UpdateOnSplitOpFunc = std::function<Status(const consensus::ReplicateMsg&)>;

--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -1700,7 +1700,8 @@ void CDCServiceImpl::GetChanges(
 
   // Acquire per-tablet CDCSDK metrics so the rest of GetChanges can record per-phase
   // latencies and per-call batch sizes. Skipped for xCluster (different metric class) and for
-  // the sys catalog tablet (same guard used by UpdateTabletMetrics below).
+  // the sys catalog tablet (same guard used by UpdateTabletMetrics below). Total RPC latency
+  // is already covered by the server-wide handler_latency_yb_cdc_CDCService_GetChanges.
   std::shared_ptr<xrepl::CDCSDKTabletMetrics> cdc_sdk_metrics;
   if (record.GetSourceType() == CDCSDK &&
       producer_tablet.tablet_id != master::kSysCatalogTabletId) {
@@ -1709,13 +1710,6 @@ void CDCServiceImpl::GetChanges(
       cdc_sdk_metrics = std::move(metrics_result.get());
     }
   }
-  // Record total RPC latency (per-tablet) on every exit path.
-  auto record_total_latency = ScopeExit([&cdc_sdk_metrics, start_time]() {
-    if (cdc_sdk_metrics) {
-      cdc_sdk_metrics->cdcsdk_get_changes_total_latency->Increment(
-          MonoTime::Now().GetDeltaSince(start_time).ToMicroseconds());
-    }
-  });
 
   // Polling sys catalog tablet is only supported for CDC.
   RPC_CHECK_AND_RETURN_ERROR(

--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -1698,6 +1698,25 @@ void CDCServiceImpl::GetChanges(
       CDCErrorPB::INTERNAL_ERROR, context);
   StreamMetadata& record = *stream_meta_ptr;
 
+  // Acquire per-tablet CDCSDK metrics so the rest of GetChanges can record per-phase
+  // latencies and per-call batch sizes. Skipped for xCluster (different metric class) and for
+  // the sys catalog tablet (same guard used by UpdateTabletMetrics below).
+  std::shared_ptr<xrepl::CDCSDKTabletMetrics> cdc_sdk_metrics;
+  if (record.GetSourceType() == CDCSDK &&
+      producer_tablet.tablet_id != master::kSysCatalogTabletId) {
+    auto metrics_result = GetCDCSDKTabletMetrics(*tablet_peer.get(), stream_id);
+    if (metrics_result.ok()) {
+      cdc_sdk_metrics = std::move(metrics_result.get());
+    }
+  }
+  // Record total RPC latency (per-tablet) on every exit path.
+  auto record_total_latency = ScopeExit([&cdc_sdk_metrics, start_time]() {
+    if (cdc_sdk_metrics) {
+      cdc_sdk_metrics->cdcsdk_get_changes_total_latency->Increment(
+          MonoTime::Now().GetDeltaSince(start_time).ToMicroseconds());
+    }
+  });
+
   // Polling sys catalog tablet is only supported for CDC.
   RPC_CHECK_AND_RETURN_ERROR(
       !tablet_peer->tablet_metadata()->IsSysCatalog() || record.GetSourceType() == CDCSDK,
@@ -1770,6 +1789,9 @@ void CDCServiceImpl::GetChanges(
 
   // Get opId from request.
   if (!GetFromOpId(req, &from_op_id, &cdc_sdk_from_op_id)) {
+    ScopedLatencyMetric<EventStats> scoped_last_checkpoint(
+        cdc_sdk_metrics ? cdc_sdk_metrics->cdcsdk_get_last_checkpoint_latency
+                        : scoped_refptr<EventStats>{});
     auto last_checkpoint = RPC_VERIFY_RESULT(
         GetLastCheckpoint(producer_tablet, stream_meta_ptr.get()->GetSourceType(), false),
         resp->mutable_error(), CDCErrorPB::INTERNAL_ERROR, context);
@@ -1901,6 +1923,15 @@ void CDCServiceImpl::GetChanges(
     if (FLAGS_enable_cdcsdk_setting_get_changes_response_byte_limit &&
         req->has_getchanges_resp_max_size_bytes()) {
       getchanges_resp_max_size_bytes = req->getchanges_resp_max_size_bytes();
+    }
+
+    // Plumb the per-tablet metrics through to the producer for per-phase instrumentation.
+    throughput_metrics.tablet_metrics = cdc_sdk_metrics.get();
+
+    // Record pre-flight latency: everything from RPC entry up to the GetChangesForCDCSDK call.
+    if (cdc_sdk_metrics) {
+      cdc_sdk_metrics->cdcsdk_get_changes_preflight_latency->Increment(
+          MonoTime::Now().GetDeltaSince(start_time).ToMicroseconds());
     }
 
     status = GetChangesForCDCSDK(
@@ -2089,12 +2120,17 @@ void CDCServiceImpl::GetChanges(
       }
 
       bool force_update = req->force_update_cdc_state_checkpoint() || snapshot_bootstrap;
-      RPC_STATUS_RETURN_ERROR(
-          UpdateCheckpointAndActiveTime(
-              producer_tablet, OpId::FromPB(resp->checkpoint().op_id()), commit_op_id,
-              last_record_hybrid_time, cdc_sdk_safe_time, record.GetSourceType(), force_update,
-              is_snapshot, snapshot_key, (is_snapshot && is_colocated) ? req->table_id() : ""),
-          resp->mutable_error(), CDCErrorPB::INTERNAL_ERROR, context);
+      {
+        ScopedLatencyMetric<EventStats> scoped_update_checkpoint(
+            cdc_sdk_metrics ? cdc_sdk_metrics->cdcsdk_update_checkpoint_latency
+                            : scoped_refptr<EventStats>{});
+        RPC_STATUS_RETURN_ERROR(
+            UpdateCheckpointAndActiveTime(
+                producer_tablet, OpId::FromPB(resp->checkpoint().op_id()), commit_op_id,
+                last_record_hybrid_time, cdc_sdk_safe_time, record.GetSourceType(), force_update,
+                is_snapshot, snapshot_key, (is_snapshot && is_colocated) ? req->table_id() : ""),
+            resp->mutable_error(), CDCErrorPB::INTERNAL_ERROR, context);
+      }
     }
 
     // TODO(#25632): Due to incorrect memory tracking in log cache, we accumulate a lot of untracked
@@ -2116,6 +2152,14 @@ void CDCServiceImpl::GetChanges(
     UpdateTabletMetrics(
         *resp, producer_tablet, tablet_peer, from_op_id, record, last_readable_index,
         have_more_messages, throughput_metrics);
+
+    // Per-call CDCSDK batch-size histograms.
+    if (cdc_sdk_metrics) {
+      cdc_sdk_metrics->cdcsdk_wal_records_read->Increment(throughput_metrics.wal_records_read);
+      cdc_sdk_metrics->cdcsdk_wal_bytes_read->Increment(throughput_metrics.wal_bytes_read);
+      cdc_sdk_metrics->cdcsdk_response_records->Increment(resp->cdc_sdk_proto_records_size());
+      cdc_sdk_metrics->cdcsdk_response_bytes->Increment(resp->ByteSizeLong());
+    }
   }
 
   if (report_tablet_split) {

--- a/src/yb/cdc/cdcsdk_producer.cc
+++ b/src/yb/cdc/cdcsdk_producer.cc
@@ -12,6 +12,7 @@
 
 #include "yb/cdc/cdc_producer.h"
 
+#include "yb/cdc/xrepl_metrics.h"
 #include "yb/cdc/xrepl_stream_metadata.h"
 
 #include "yb/client/client.h"
@@ -50,6 +51,7 @@
 #include "yb/tablet/transaction_participant.h"
 
 #include "yb/util/logging.h"
+#include "yb/util/metrics.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status.h"
 #include "yb/util/status_format.h"
@@ -122,6 +124,27 @@ using dockv::PrimitiveValue;
 using dockv::SchemaPackingStorage;
 
 namespace {
+
+// Returns the latency event-stats pointer if both throughput_metrics and its tablet_metrics
+// are populated, else an empty scoped_refptr (ScopedLatencyMetric handles null as a no-op).
+inline scoped_refptr<EventStats> GetCDCSDKLatency(
+    CDCThroughputMetrics* tm,
+    scoped_refptr<EventStats> xrepl::CDCSDKTabletMetrics::*member) {
+  if (!tm || !tm->tablet_metrics) {
+    return {};
+  }
+  return tm->tablet_metrics->*member;
+}
+
+inline void IncrementCDCSDKCounter(
+    CDCThroughputMetrics* tm,
+    scoped_refptr<Counter> xrepl::CDCSDKTabletMetrics::*member) {
+  if (!tm || !tm->tablet_metrics) {
+    return;
+  }
+  IncrementCounter(tm->tablet_metrics->*member);
+}
+
 YB_DEFINE_ENUM(OpType, (INSERT)(UPDATE)(DELETE));
 
 Result<bool> IsPackedRowUpdate(const dockv::ValueEntryType value_type, Slice value_slice) {
@@ -805,7 +828,11 @@ Result<SchemaDetails> GetOrPopulateRequiredSchemaDetails(
       continue;
     }
 
-    auto result = client->GetTableSchemaFromSysCatalog(cur_table_id, read_hybrid_time);
+    auto result = ([&]() {
+      ScopedLatencyMetric<EventStats> sl(GetCDCSDKLatency(
+          throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_schema_lookup_latency));
+      return client->GetTableSchemaFromSysCatalog(cur_table_id, read_hybrid_time);
+    })();
     // Failed to get specific schema version from the system catalog, use the latest
     // schema version for the key-value decoding.
     if (!result.ok()) {
@@ -1840,10 +1867,17 @@ Status ProcessIntents(
     TEST_SYNC_POINT("AddBeginRecord::End");
   }
 
-  RETURN_NOT_OK(tablet->GetIntentsForCDC(transaction_id, aborted, keyValueIntents,
-    stream_state));
+  {
+    ScopedLatencyMetric<EventStats> sl(GetCDCSDKLatency(
+        throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_get_intents_latency));
+    RETURN_NOT_OK(tablet->GetIntentsForCDC(transaction_id, aborted, keyValueIntents,
+      stream_state));
+  }
   VLOG(1) << "The size of intentKeyValues for transaction id: " << transaction_id
           << ", with apply record op_id : " << op_id << ", is: " << (*keyValueIntents).size();
+  IncrementStats(GetCDCSDKLatency(
+      throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_intents_per_txn),
+      static_cast<int64_t>(keyValueIntents->size()));
 
   const OpId& checkpoint_op_id = tablet_peer->GetLatestCheckPoint();
   if ((*keyValueIntents).size() == 0 && op_id <= checkpoint_op_id) {
@@ -2114,7 +2148,8 @@ Status GetConsistentWALRecords(
     const int64_t& safe_hybrid_time_req, const CoarseTimePoint& deadline,
     std::vector<std::shared_ptr<yb::consensus::LWReplicateMsg>>* consistent_wal_records,
     std::vector<std::shared_ptr<yb::consensus::LWReplicateMsg>>* all_checkpoints,
-    HybridTime* last_read_wal_op_record_time, bool* is_entire_wal_read) {
+    HybridTime* last_read_wal_op_record_time, bool* is_entire_wal_read,
+    CDCThroughputMetrics* throughput_metrics) {
   VLOG(2) << "Getting consistent WAL records. safe_hybrid_time_req: " << safe_hybrid_time_req
           << ", consistent_safe_time: " << *consistent_safe_time
           << ", last_seen_op_id: " << last_seen_op_id->ToString()
@@ -2149,6 +2184,10 @@ Status GetConsistentWALRecords(
 
     if (read_ops.read_from_disk_size && mem_tracker) {
       (*consumption) = ScopedTrackedConsumption(mem_tracker, read_ops.read_from_disk_size);
+    }
+    if (throughput_metrics) {
+      throughput_metrics->wal_bytes_read += read_ops.read_from_disk_size;
+      throughput_metrics->wal_records_read += read_ops.messages.size();
     }
 
     for (const auto& msg : read_ops.messages) {
@@ -2250,7 +2289,8 @@ Status GetWALRecords(
     uint64_t consistent_safe_time, OpId* last_seen_op_id, int64_t** last_readable_opid_index,
     const int64_t& safe_hybrid_time, const CoarseTimePoint& deadline, bool skip_intents,
     std::vector<std::shared_ptr<yb::consensus::LWReplicateMsg>>* wal_records,
-    std::vector<std::shared_ptr<yb::consensus::LWReplicateMsg>>* all_checkpoints) {
+    std::vector<std::shared_ptr<yb::consensus::LWReplicateMsg>>* all_checkpoints,
+    CDCThroughputMetrics* throughput_metrics) {
   auto consensus = VERIFY_RESULT(tablet_peer->GetConsensus());
   auto read_ops = VERIFY_RESULT(consensus->ReadReplicatedMessagesForCDC(
       *last_seen_op_id, *last_readable_opid_index, deadline));
@@ -2264,6 +2304,10 @@ Status GetWALRecords(
 
   if (read_ops.read_from_disk_size && mem_tracker) {
     (*consumption) = ScopedTrackedConsumption(mem_tracker, read_ops.read_from_disk_size);
+  }
+  if (throughput_metrics) {
+    throughput_metrics->wal_bytes_read += read_ops.read_from_disk_size;
+    throughput_metrics->wal_records_read += read_ops.messages.size();
   }
 
   for (const auto& msg : read_ops.messages) {
@@ -2680,6 +2724,9 @@ Status GetChangesForCDCSDK(
   auto scope_exit = ScopeExit([&] { docdb::DeleteMemoryContextForCDCWrapper(); });
 
   DCHECK(throughput_metrics);
+  // Per-tablet metric pointer used by the ScopedLatencyMetric wrappers below. May be null on
+  // the xCluster path or when metric acquisition failed; ScopedLatencyMetric handles null.
+  xrepl::CDCSDKTabletMetrics* tm = throughput_metrics->tablet_metrics;
   auto op_id = OpId::FromPB(from_op_id);
   VLOG(1) << "GetChanges request has from_op_id: " << AsString(from_op_id)
           << ", safe_hybrid_time: " << safe_hybrid_time_req
@@ -2703,9 +2750,14 @@ Status GetChangesForCDCSDK(
   } else {
     leader_safe_time = *leader_safe_time_result;
   }
-  uint64_t consistent_stream_safe_time = VERIFY_RESULT(GetConsistentStreamSafeTime(
-      tablet_peer, tablet_ptr, leader_safe_time, safe_hybrid_time_req, deadline,
-      &txn_load_in_progress));
+  uint64_t consistent_stream_safe_time;
+  {
+    ScopedLatencyMetric<EventStats> scoped_safe_time(
+        tm ? tm->cdcsdk_safe_time_wait_latency : scoped_refptr<EventStats>{});
+    consistent_stream_safe_time = VERIFY_RESULT(GetConsistentStreamSafeTime(
+        tablet_peer, tablet_ptr, leader_safe_time, safe_hybrid_time_req, deadline,
+        &txn_load_in_progress));
+  }
   OpId historical_max_op_id = tablet_ptr->transaction_participant()
                                   ? tablet_ptr->transaction_participant()->GetHistoricalMaxOpId()
                                   : OpId::Invalid();
@@ -2739,19 +2791,23 @@ Status GetChangesForCDCSDK(
     std::vector<std::shared_ptr<yb::consensus::LWReplicateMsg>> wal_records, all_checkpoints;
 
     DCHECK(last_readable_opid_index);
-    if (FLAGS_cdc_enable_consistent_records)
-      RETURN_NOT_OK(GetConsistentWALRecords(
-          tablet_peer, mem_tracker, msgs_holder, &consumption, &consistent_stream_safe_time,
-          historical_max_op_id, &wait_for_wal_update, &last_seen_op_id, *last_readable_opid_index,
-          safe_hybrid_time_req, deadline, &wal_records, &all_checkpoints,
-          &last_read_wal_op_record_time, &is_entire_wal_read));
-    else
-      // 'skip_intents' is true here because we want the first transaction to be the partially
-      // streamed transaction.
-      RETURN_NOT_OK(GetWALRecords(
-          tablet_peer, mem_tracker, msgs_holder, &consumption, consistent_stream_safe_time,
-          &last_seen_op_id, &last_readable_opid_index, safe_hybrid_time_req, deadline, true,
-          &wal_records, &all_checkpoints));
+    {
+      ScopedLatencyMetric<EventStats> scoped_wal_read(
+          tm ? tm->cdcsdk_wal_read_latency : scoped_refptr<EventStats>{});
+      if (FLAGS_cdc_enable_consistent_records)
+        RETURN_NOT_OK(GetConsistentWALRecords(
+            tablet_peer, mem_tracker, msgs_holder, &consumption, &consistent_stream_safe_time,
+            historical_max_op_id, &wait_for_wal_update, &last_seen_op_id, *last_readable_opid_index,
+            safe_hybrid_time_req, deadline, &wal_records, &all_checkpoints,
+            &last_read_wal_op_record_time, &is_entire_wal_read, throughput_metrics));
+      else
+        // 'skip_intents' is true here because we want the first transaction to be the partially
+        // streamed transaction.
+        RETURN_NOT_OK(GetWALRecords(
+            tablet_peer, mem_tracker, msgs_holder, &consumption, consistent_stream_safe_time,
+            &last_seen_op_id, &last_readable_opid_index, safe_hybrid_time_req, deadline, true,
+            &wal_records, &all_checkpoints, throughput_metrics));
+    }
 
     have_more_messages = HaveMoreMessages(true);
 
@@ -2797,11 +2853,15 @@ Status GetChangesForCDCSDK(
                     wal_records[wal_segment_index]->transaction_state().aborted().set()))
               : SubtxnSet();
 
-      RETURN_NOT_OK(ProcessIntentsWithInvalidSchemaRetry(
-          op_id, transaction_id, xrepl_origin_id, aborted_subtxns, stream_metadata,
-          enum_oid_label_map, composite_atts_map, request_source, resp, &consumption, &checkpoint,
-          tablet_peer, &keyValueIntents, &stream_state, client, cached_schema_details,
-          schema_packing_storages, commit_timestamp, throughput_metrics));
+      {
+        ScopedLatencyMetric<EventStats> sl(GetCDCSDKLatency(
+            throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_process_intents_latency));
+        RETURN_NOT_OK(ProcessIntentsWithInvalidSchemaRetry(
+            op_id, transaction_id, xrepl_origin_id, aborted_subtxns, stream_metadata,
+            enum_oid_label_map, composite_atts_map, request_source, resp, &consumption,
+            &checkpoint, tablet_peer, &keyValueIntents, &stream_state, client,
+            cached_schema_details, schema_packing_storages, commit_timestamp, throughput_metrics));
+      }
 
       if (checkpoint.write_id() == 0 && checkpoint.key().empty() && wal_records.size()) {
         AcknowledgeStreamedMultiShardTxn(
@@ -2848,9 +2908,13 @@ Status GetChangesForCDCSDK(
     do {
       size_t next_checkpoint_index = 0;
 
-      consistent_stream_safe_time = VERIFY_RESULT(GetConsistentStreamSafeTime(
-          tablet_peer, tablet_ptr, leader_safe_time, safe_hybrid_time_req, deadline,
-          &txn_load_in_progress));
+      {
+        ScopedLatencyMetric<EventStats> scoped_safe_time(
+            tm ? tm->cdcsdk_safe_time_wait_latency : scoped_refptr<EventStats>{});
+        consistent_stream_safe_time = VERIFY_RESULT(GetConsistentStreamSafeTime(
+            tablet_peer, tablet_ptr, leader_safe_time, safe_hybrid_time_req, deadline,
+            &txn_load_in_progress));
+      }
 
       if (txn_load_in_progress) {
         LOG(INFO) << "Loading of transactions is in progress for tablet: " << tablet_id
@@ -2859,19 +2923,24 @@ Status GetChangesForCDCSDK(
       }
 
       DCHECK(last_readable_opid_index);
-      if (FLAGS_cdc_enable_consistent_records)
-        RETURN_NOT_OK(GetConsistentWALRecords(
-            tablet_peer, mem_tracker, msgs_holder, &consumption, &consistent_stream_safe_time,
-            historical_max_op_id, &wait_for_wal_update, &last_seen_op_id, *last_readable_opid_index,
-            safe_hybrid_time_req, deadline, &wal_records, &all_checkpoints,
-            &last_read_wal_op_record_time, &is_entire_wal_read));
-      else
-        // 'skip_intents' is false otherwise in case the complete wal segment is filled with
-        // intents we will break the loop thinking that WAL has no more records.
-        RETURN_NOT_OK(GetWALRecords(
-            tablet_peer, mem_tracker, msgs_holder, &consumption, consistent_stream_safe_time,
-            &last_seen_op_id, &last_readable_opid_index, safe_hybrid_time_req, deadline, false,
-            &wal_records, &all_checkpoints));
+      {
+        ScopedLatencyMetric<EventStats> scoped_wal_read(
+            tm ? tm->cdcsdk_wal_read_latency : scoped_refptr<EventStats>{});
+        if (FLAGS_cdc_enable_consistent_records)
+          RETURN_NOT_OK(GetConsistentWALRecords(
+              tablet_peer, mem_tracker, msgs_holder, &consumption, &consistent_stream_safe_time,
+              historical_max_op_id, &wait_for_wal_update, &last_seen_op_id,
+              *last_readable_opid_index, safe_hybrid_time_req, deadline, &wal_records,
+              &all_checkpoints, &last_read_wal_op_record_time, &is_entire_wal_read,
+              throughput_metrics));
+        else
+          // 'skip_intents' is false otherwise in case the complete wal segment is filled with
+          // intents we will break the loop thinking that WAL has no more records.
+          RETURN_NOT_OK(GetWALRecords(
+              tablet_peer, mem_tracker, msgs_holder, &consumption, consistent_stream_safe_time,
+              &last_seen_op_id, &last_readable_opid_index, safe_hybrid_time_req, deadline, false,
+              &wal_records, &all_checkpoints, throughput_metrics));
+      }
 
       if (wait_for_wal_update) {
         VLOG_WITH_FUNC(1)
@@ -2957,6 +3026,8 @@ Status GetChangesForCDCSDK(
 
         switch (msg->op_type()) {
           case consensus::OperationType::UPDATE_TRANSACTION_OP:
+            IncrementCDCSDKCounter(
+                throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_update_txn_ops_seen);
             // Ignore intents.
             // Read from IntentDB after they have been applied.
             if (msg->transaction_state().status() == TransactionStatus::APPLYING) {
@@ -2995,12 +3066,17 @@ Status GetChangesForCDCSDK(
                       << msg->id().ShortDebugString() << ", tablet_id: " << tablet_id
                       << ", transaction_id: " << txn_id << ", commit_time: " << *commit_timestamp;
 
-              RETURN_NOT_OK(ProcessIntentsWithInvalidSchemaRetry(
-                  op_id, txn_id, xrepl_origin_id, aborted_subtxns, stream_metadata,
-                  enum_oid_label_map, composite_atts_map, request_source, resp, &consumption,
-                  &checkpoint, tablet_peer, &intents, &new_stream_state, client,
-                  cached_schema_details, schema_packing_storages, *commit_timestamp,
-                  throughput_metrics));
+              {
+                ScopedLatencyMetric<EventStats> sl(GetCDCSDKLatency(
+                    throughput_metrics,
+                    &xrepl::CDCSDKTabletMetrics::cdcsdk_process_intents_latency));
+                RETURN_NOT_OK(ProcessIntentsWithInvalidSchemaRetry(
+                    op_id, txn_id, xrepl_origin_id, aborted_subtxns, stream_metadata,
+                    enum_oid_label_map, composite_atts_map, request_source, resp, &consumption,
+                    &checkpoint, tablet_peer, &intents, &new_stream_state, client,
+                    cached_schema_details, schema_packing_storages, *commit_timestamp,
+                    throughput_metrics));
+              }
               streamed_txns.insert(txn_id.ToString());
 
               if (new_stream_state.write_id != 0 && !new_stream_state.key.empty()) {
@@ -3022,6 +3098,8 @@ Status GetChangesForCDCSDK(
             break;
 
           case consensus::OperationType::WRITE_OP: {
+            IncrementCDCSDKCounter(
+                throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_write_ops_seen);
             const auto& batch = msg->write().write_batch();
             *commit_timestamp = HybridTime::FromPB(msg->hybrid_time());
 
@@ -3030,6 +3108,9 @@ Status GetChangesForCDCSDK(
                     << ", hybrid_time: " << *commit_timestamp;
 
             if (!batch.has_transaction()) {
+              ScopedLatencyMetric<EventStats> sl(GetCDCSDKLatency(
+                  throughput_metrics,
+                  &xrepl::CDCSDKTabletMetrics::cdcsdk_populate_write_record_latency));
               RETURN_NOT_OK(PopulateCDCSDKWriteRecordWithInvalidSchemaRetry(
                   msg, stream_metadata, tablet_peer, enum_oid_label_map, composite_atts_map,
                   request_source, cached_schema_details, schema_packing_storages, resp, client,
@@ -3044,6 +3125,8 @@ Status GetChangesForCDCSDK(
           } break;
 
           case consensus::OperationType::CHANGE_METADATA_OP: {
+            IncrementCDCSDKCounter(
+                throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_change_metadata_ops_seen);
             VLOG(3) << "Will stream a DDL record. " << msg->ShortDebugString();
             RETURN_NOT_OK(SchemaFromPB(
                 msg->change_metadata_request().schema().ToGoogleProtobuf(), &current_schema));
@@ -3070,7 +3153,12 @@ Status GetChangesForCDCSDK(
                 .schema_version = msg->change_metadata_request().schema_version(),
                 .schema = std::make_shared<Schema>(current_schema)};
             changed_schema_version = msg->change_metadata_request().schema_version();
-            auto result = client->GetTableSchemaFromSysCatalog(table_id, msg->hybrid_time());
+            auto result = ([&]() {
+              ScopedLatencyMetric<EventStats> sl(GetCDCSDKLatency(
+                  throughput_metrics,
+                  &xrepl::CDCSDKTabletMetrics::cdcsdk_schema_lookup_latency));
+              return client->GetTableSchemaFromSysCatalog(table_id, msg->hybrid_time());
+            })();
             if (!result.ok()) {
               LOG(WARNING)
                   << "Failed to get the specific schema version from system catalog for table: "
@@ -3119,6 +3207,8 @@ Status GetChangesForCDCSDK(
           } break;
 
           case consensus::OperationType::TRUNCATE_OP: {
+            IncrementCDCSDKCounter(
+                throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_truncate_ops_seen);
             if (FLAGS_stream_truncate_record) {
               RETURN_NOT_OK(PopulateCDCSDKTruncateRecord(
                   msg, resp->add_cdc_sdk_proto_records(), current_schema, throughput_metrics));
@@ -3134,6 +3224,8 @@ Status GetChangesForCDCSDK(
           } break;
 
           case yb::consensus::OperationType::SPLIT_OP: {
+            IncrementCDCSDKCounter(
+                throughput_metrics, &xrepl::CDCSDKTabletMetrics::cdcsdk_split_ops_seen);
             const TableId& table_id = tablet_ptr->metadata()->table_id();
             auto op_id = OpId::FromPB(msg->id());
 

--- a/src/yb/cdc/xrepl_metrics.cc
+++ b/src/yb/cdc/xrepl_metrics.cc
@@ -148,6 +148,95 @@ METRIC_DEFINE_gauge_uint64(cdcsdk, cdcsdk_flush_lag, "CDCSDK flush Lag",
     "Lag between last committed record in the WAL and the replication slot's restart time.",
     {0 /* zero means we don't expose it as counter */, yb::AggregationFunction::kMax});
 
+// CDCSDK per-phase latency histograms for the GetChanges RPC.
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_get_changes_total_latency,
+    "CDCSDK GetChanges total latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) for the full CDCSDK GetChanges RPC, measured per tablet.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_get_changes_preflight_latency,
+    "CDCSDK GetChanges preflight latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent before entering GetChangesForCDCSDK: semaphore, validation, "
+    "stream/tablet/leader lookup, schema/enum/composite caches.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_get_last_checkpoint_latency,
+    "CDCSDK GetLastCheckpoint latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in GetLastCheckpoint (cdc_state read) when the client sends no "
+    "from_op_id.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_update_checkpoint_latency,
+    "CDCSDK UpdateCheckpoint latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in UpdateCheckpointAndActiveTime (cdc_state write) on "
+    "EXPLICIT ack.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_wal_read_latency,
+    "CDCSDK WAL read latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent reading WAL records during a single GetChanges call.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_process_intents_latency,
+    "CDCSDK ProcessIntents latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in ProcessIntents (intent fetch + record population) per "
+    "multi-shard transaction.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_get_intents_latency,
+    "CDCSDK GetIntentsForCDC latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in tablet->GetIntentsForCDC alone (IntentsDB read inside "
+    "ProcessIntents).");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_populate_write_record_latency,
+    "CDCSDK PopulateWriteRecord latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in PopulateCDCSDKWriteRecord for single-shard writes.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_schema_lookup_latency,
+    "CDCSDK schema lookup latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in client->GetTableSchemaFromSysCatalog (master round-trips).");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_safe_time_wait_latency,
+    "CDCSDK safe time wait latency", yb::MetricUnit::kMicroseconds,
+    "Time (microseconds) spent in GetConsistentStreamSafeTime (waiting for safe time / txn "
+    "load).");
+
+// CDCSDK per-call batch-size histograms (one observation per successful GetChanges).
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_wal_records_read,
+    "CDCSDK WAL records read per call", yb::MetricUnit::kEntries,
+    "Number of WAL records read during a single GetChanges call.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_wal_bytes_read,
+    "CDCSDK WAL bytes read per call", yb::MetricUnit::kBytes,
+    "Total bytes read from disk for WAL records during a single GetChanges call.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_intents_per_txn,
+    "CDCSDK intents per transaction", yb::MetricUnit::kEntries,
+    "Number of intent key/value pairs read for a single multi-shard transaction.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_response_records,
+    "CDCSDK response records per call", yb::MetricUnit::kEntries,
+    "Number of CDC SDK proto records emitted in a single GetChanges response.");
+
+METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_response_bytes,
+    "CDCSDK response bytes per call", yb::MetricUnit::kBytes,
+    "Serialized size in bytes of a single GetChanges response.");
+
+// CDCSDK per-optype counters incremented in the GetChangesForCDCSDK main loop.
+METRIC_DEFINE_counter(cdcsdk, cdcsdk_write_ops_seen,
+    "CDCSDK WRITE_OP records seen", yb::MetricUnit::kEntries,
+    "Number of WRITE_OP WAL records processed by GetChangesForCDCSDK.");
+
+METRIC_DEFINE_counter(cdcsdk, cdcsdk_update_txn_ops_seen,
+    "CDCSDK UPDATE_TRANSACTION_OP records seen", yb::MetricUnit::kEntries,
+    "Number of UPDATE_TRANSACTION_OP WAL records processed by GetChangesForCDCSDK.");
+
+METRIC_DEFINE_counter(cdcsdk, cdcsdk_change_metadata_ops_seen,
+    "CDCSDK CHANGE_METADATA_OP records seen", yb::MetricUnit::kEntries,
+    "Number of CHANGE_METADATA_OP WAL records processed by GetChangesForCDCSDK.");
+
+METRIC_DEFINE_counter(cdcsdk, cdcsdk_truncate_ops_seen,
+    "CDCSDK TRUNCATE_OP records seen", yb::MetricUnit::kEntries,
+    "Number of TRUNCATE_OP WAL records processed by GetChangesForCDCSDK.");
+
+METRIC_DEFINE_counter(cdcsdk, cdcsdk_split_ops_seen,
+    "CDCSDK SPLIT_OP records seen", yb::MetricUnit::kEntries,
+    "Number of SPLIT_OP WAL records processed by GetChangesForCDCSDK.");
+
 // CDC Server Metrics
 METRIC_DEFINE_counter(server, cdc_rpc_proxy_count, "CDC Rpc Proxy Count", yb::MetricUnit::kRequests,
   "Number of CDC GetChanges requests that required proxy forwarding");
@@ -198,6 +287,26 @@ CDCSDKTabletMetrics::CDCSDKTabletMetrics(const scoped_refptr<MetricEntity>& enti
       GINIT(cdcsdk_expiry_time_ms),
       GINIT(cdcsdk_last_sent_physicaltime),
       GINIT(cdcsdk_flush_lag),
+      MINIT(cdcsdk_get_changes_total_latency),
+      MINIT(cdcsdk_get_changes_preflight_latency),
+      MINIT(cdcsdk_get_last_checkpoint_latency),
+      MINIT(cdcsdk_update_checkpoint_latency),
+      MINIT(cdcsdk_wal_read_latency),
+      MINIT(cdcsdk_process_intents_latency),
+      MINIT(cdcsdk_get_intents_latency),
+      MINIT(cdcsdk_populate_write_record_latency),
+      MINIT(cdcsdk_schema_lookup_latency),
+      MINIT(cdcsdk_safe_time_wait_latency),
+      MINIT(cdcsdk_wal_records_read),
+      MINIT(cdcsdk_wal_bytes_read),
+      MINIT(cdcsdk_intents_per_txn),
+      MINIT(cdcsdk_response_records),
+      MINIT(cdcsdk_response_bytes),
+      MINIT(cdcsdk_write_ops_seen),
+      MINIT(cdcsdk_update_txn_ops_seen),
+      MINIT(cdcsdk_change_metadata_ops_seen),
+      MINIT(cdcsdk_truncate_ops_seen),
+      MINIT(cdcsdk_split_ops_seen),
       entity_(entity) {}
 
 void CDCSDKTabletMetrics::ClearMetrics() {
@@ -207,6 +316,12 @@ void CDCSDKTabletMetrics::ClearMetrics() {
   cdcsdk_expiry_time_ms->set_value(0);
   cdcsdk_last_sent_physicaltime->set_value(0);
   cdcsdk_flush_lag->set_value(0);
+  cdcsdk_write_ops_seen.reset();
+  cdcsdk_update_txn_ops_seen.reset();
+  cdcsdk_change_metadata_ops_seen.reset();
+  cdcsdk_truncate_ops_seen.reset();
+  cdcsdk_split_ops_seen.reset();
+  // EventStats are reset implicitly when the entity is re-created; no per-stat reset needed.
 }
 
 Result<std::string> CDCSDKTabletMetrics::TEST_GetAttribute(const std::string& key) const {

--- a/src/yb/cdc/xrepl_metrics.cc
+++ b/src/yb/cdc/xrepl_metrics.cc
@@ -149,10 +149,7 @@ METRIC_DEFINE_gauge_uint64(cdcsdk, cdcsdk_flush_lag, "CDCSDK flush Lag",
     {0 /* zero means we don't expose it as counter */, yb::AggregationFunction::kMax});
 
 // CDCSDK per-phase latency histograms for the GetChanges RPC.
-METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_get_changes_total_latency,
-    "CDCSDK GetChanges total latency", yb::MetricUnit::kMicroseconds,
-    "Time (microseconds) for the full CDCSDK GetChanges RPC, measured per tablet.");
-
+// (Total RPC latency is covered by the server-wide handler_latency_yb_cdc_CDCService_GetChanges.)
 METRIC_DEFINE_event_stats(cdcsdk, cdcsdk_get_changes_preflight_latency,
     "CDCSDK GetChanges preflight latency", yb::MetricUnit::kMicroseconds,
     "Time (microseconds) spent before entering GetChangesForCDCSDK: semaphore, validation, "
@@ -287,7 +284,6 @@ CDCSDKTabletMetrics::CDCSDKTabletMetrics(const scoped_refptr<MetricEntity>& enti
       GINIT(cdcsdk_expiry_time_ms),
       GINIT(cdcsdk_last_sent_physicaltime),
       GINIT(cdcsdk_flush_lag),
-      MINIT(cdcsdk_get_changes_total_latency),
       MINIT(cdcsdk_get_changes_preflight_latency),
       MINIT(cdcsdk_get_last_checkpoint_latency),
       MINIT(cdcsdk_update_checkpoint_latency),

--- a/src/yb/cdc/xrepl_metrics.h
+++ b/src/yb/cdc/xrepl_metrics.h
@@ -110,6 +110,43 @@ class CDCSDKTabletMetrics {
   // Lag between last committed record in the WAL and replication slot's restart time.
   scoped_refptr<AtomicGauge<uint64_t>> cdcsdk_flush_lag;
 
+  // Per-phase latency histograms for the GetChanges RPC on the CDCSDK path.
+  // Total RPC duration (per-tablet view; complements the server-wide handler_latency).
+  scoped_refptr<EventStats> cdcsdk_get_changes_total_latency;
+  // Time spent before entering GetChangesForCDCSDK: semaphore, validation, stream/tablet/leader
+  // lookup, schema/enum/composite cache.
+  scoped_refptr<EventStats> cdcsdk_get_changes_preflight_latency;
+  // Time spent in GetLastCheckpoint (cdc_state read) when the client sends no from_op_id.
+  scoped_refptr<EventStats> cdcsdk_get_last_checkpoint_latency;
+  // Time spent in UpdateCheckpointAndActiveTime (cdc_state write) on EXPLICIT ack.
+  scoped_refptr<EventStats> cdcsdk_update_checkpoint_latency;
+  // Time spent reading WAL records (GetConsistentWALRecords / GetWALRecords).
+  scoped_refptr<EventStats> cdcsdk_wal_read_latency;
+  // Time in ProcessIntentsWithInvalidSchemaRetry (intent fetch + record population).
+  scoped_refptr<EventStats> cdcsdk_process_intents_latency;
+  // Time in tablet->GetIntentsForCDC alone (the IntentsDB read inside ProcessIntents).
+  scoped_refptr<EventStats> cdcsdk_get_intents_latency;
+  // Time in PopulateCDCSDKWriteRecordWithInvalidSchemaRetry for single-shard writes.
+  scoped_refptr<EventStats> cdcsdk_populate_write_record_latency;
+  // Time in client->GetTableSchemaFromSysCatalog (master round-trips).
+  scoped_refptr<EventStats> cdcsdk_schema_lookup_latency;
+  // Time in GetConsistentStreamSafeTime (waiting for safe time / txn load).
+  scoped_refptr<EventStats> cdcsdk_safe_time_wait_latency;
+
+  // Per-call batch-size histograms (observed once per successful GetChanges).
+  scoped_refptr<EventStats> cdcsdk_wal_records_read;
+  scoped_refptr<EventStats> cdcsdk_wal_bytes_read;
+  scoped_refptr<EventStats> cdcsdk_intents_per_txn;
+  scoped_refptr<EventStats> cdcsdk_response_records;
+  scoped_refptr<EventStats> cdcsdk_response_bytes;
+
+  // Per-optype counters incremented in the GetChangesForCDCSDK main loop.
+  scoped_refptr<Counter> cdcsdk_write_ops_seen;
+  scoped_refptr<Counter> cdcsdk_update_txn_ops_seen;
+  scoped_refptr<Counter> cdcsdk_change_metadata_ops_seen;
+  scoped_refptr<Counter> cdcsdk_truncate_ops_seen;
+  scoped_refptr<Counter> cdcsdk_split_ops_seen;
+
   Result<std::string> TEST_GetAttribute(const std::string& key) const;
 
  private:

--- a/src/yb/cdc/xrepl_metrics.h
+++ b/src/yb/cdc/xrepl_metrics.h
@@ -111,8 +111,7 @@ class CDCSDKTabletMetrics {
   scoped_refptr<AtomicGauge<uint64_t>> cdcsdk_flush_lag;
 
   // Per-phase latency histograms for the GetChanges RPC on the CDCSDK path.
-  // Total RPC duration (per-tablet view; complements the server-wide handler_latency).
-  scoped_refptr<EventStats> cdcsdk_get_changes_total_latency;
+  // (Total RPC latency is covered by the server-wide handler_latency_yb_cdc_CDCService_GetChanges.)
   // Time spent before entering GetChangesForCDCSDK: semaphore, validation, stream/tablet/leader
   // lookup, schema/enum/composite cache.
   scoped_refptr<EventStats> cdcsdk_get_changes_preflight_latency;


### PR DESCRIPTION
## Summary

Adds per-tablet histograms and counters on `CDCSDKTabletMetrics` so operators can attribute slow CDCSDK `GetChanges` RPCs to specific phases. Today the only visibility is the server-wide `handler_latency_yb_cdc_CDCService_GetChanges` and a few aggregate counters, which is not enough to tell whether the time is going to WAL reads, intent reads, schema lookups, the `cdc_state` checkpoint write, or somewhere else.

Scope: CDCSDK only. The xCluster path is unchanged.

### Per-phase latency histograms (microseconds, per stream/tablet)

Total RPC duration is already covered by the server-wide `handler_latency_yb_cdc_CDCService_GetChanges`; the per-phase metrics below let operators attribute time within that total.

| Metric | What it measures |
|---|---|
| `cdcsdk_get_changes_preflight_latency` | RPC entry up to `GetChangesForCDCSDK` (semaphore, validation, stream/tablet/leader lookup, schema/enum/composite caches) |
| `cdcsdk_get_last_checkpoint_latency` | `GetLastCheckpoint` (`cdc_state` read) when the client sends no `from_op_id` |
| `cdcsdk_update_checkpoint_latency` | `UpdateCheckpointAndActiveTime` (`cdc_state` write) on EXPLICIT ack |
| `cdcsdk_wal_read_latency` | `GetConsistentWALRecords` / `GetWALRecords` |
| `cdcsdk_process_intents_latency` | `ProcessIntentsWithInvalidSchemaRetry` per multi-shard txn |
| `cdcsdk_get_intents_latency` | `tablet->GetIntentsForCDC` alone (separates IntentsDB read from record population) |
| `cdcsdk_populate_write_record_latency` | `PopulateCDCSDKWriteRecord` for single-shard writes |
| `cdcsdk_schema_lookup_latency` | `client->GetTableSchemaFromSysCatalog` (master round-trips) |
| `cdcsdk_safe_time_wait_latency` | `GetConsistentStreamSafeTime` (waiting for safe time / txn load) |

### Per-call batch-size histograms (one observation per successful response)

`cdcsdk_wal_records_read`, `cdcsdk_wal_bytes_read`, `cdcsdk_intents_per_txn`, `cdcsdk_response_records`, `cdcsdk_response_bytes`.

### Per-optype counters

Incremented in the `GetChangesForCDCSDK` main switch: `cdcsdk_write_ops_seen`, `cdcsdk_update_txn_ops_seen`, `cdcsdk_change_metadata_ops_seen`, `cdcsdk_truncate_ops_seen`, `cdcsdk_split_ops_seen`.

### Implementation notes

- Reuses the existing `CDCThroughputMetrics` struct that already threads counters from the producer to the service layer. Extended with a non-owning `xrepl::CDCSDKTabletMetrics*` pointer plus per-call WAL byte/record accumulators.
- `CDCServiceImpl::GetChanges` acquires the per-tablet metric via the existing `GetCDCSDKTabletMetrics()` lookup (skipped for xCluster and the sys catalog tablet), populates the pointer before calling `GetChangesForCDCSDK`, and emits batch-size histograms at the end of the call.
- All observation sites use `ScopedLatencyMetric<EventStats>`, which is null-safe — so the same code paths work when the per-tablet pointer is unset (xCluster, sys catalog, metric acquisition failure).
- Cardinality: roughly triples the per-tablet metric series. Same `(streams × tablets)` scaling as the existing `cdcsdk_sent_lag_micros` etc., so no new cardinality regime, but worth measuring tserver heap impact on a busy cluster.

## Test plan

- [ ] `./yb_build.sh release daemons initdb --sj --skip-pg-parquet --no-odyssey --no-ybc` builds clean
- [ ] Existing CDC tests pass: `./yb_build.sh release --cxx-test cdc_service-test` and `cdcsdk_producer-test`
- [ ] Manual smoke: spin up a single-node tserver, create a CDCSDK stream with the Debezium gRPC connector, run a workload, and verify the new `cdcsdk_*_latency` / `cdcsdk_*_read` / `cdcsdk_*_per_txn` series appear at `http://<tserver>:9000/prometheus-metrics` with non-zero counts and sensible percentiles
- [ ] Confirm the metrics show up labeled by `table_name` / `tablet_id` / `stream_id` (same labels as `cdcsdk_sent_lag_micros`)
- [ ] Confirm sys catalog tablet emits no new metrics (existing guard reused)

