### PR TITLE
[#16670] dist-trace: initialize distributed tracing in the master/tserver process

### DIFF
--- a/src/yb/tserver/db_server_base.cc
+++ b/src/yb/tserver/db_server_base.cc
@@ -28,6 +28,7 @@
 #include "yb/tserver/tserver_util_fwd.h"
 #include "yb/tserver/tserver_shared_mem.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/jsonwriter.h"
 #include "yb/util/metrics.h"
 #include "yb/util/mem_tracker.h"
@@ -50,6 +51,11 @@ DbServerBase::~DbServerBase() {
 
 Status DbServerBase::Init() {
   RETURN_NOT_OK(RpcAndWebServerBase::Init());
+
+  // Initialize distributed tracing once per process here
+  if (dist_trace::IsDistTraceEnabled()) {
+    dist_trace::InitDistTrace(name_, permanent_uuid());
+  }
 
   async_client_init_ = std::make_unique<client::AsyncClientInitializer>(
       "server_client", default_client_timeout(), permanent_uuid(), &options(), metric_entity(),
@@ -117,6 +123,10 @@ void DbServerBase::Shutdown() {
     txn_manager->Shutdown();
   }
   async_client_init_->Shutdown();
+
+  if (dist_trace::IsDistTraceEnabled()) {
+    dist_trace::ShutdownDistTrace();
+  }
 }
 
 const std::shared_future<client::YBClient*>& DbServerBase::client_future() const {


### PR DESCRIPTION
DbServerBase is the shared base of both Master and TabletServer, so
DbServerBase::Init is the single place that initializes the process-wide
dist_trace tracer (service name = server name, node id = permanent uuid)
for every DB server process -- master, tserver, and the PG backend's
server -- with DbServerBase::Shutdown tearing it down. Gated by
IsDistTraceEnabled, so it is a no-op when tracing is off.

