### PR TITLE
[#16670] dist-trace: propagate traceparent to the PG backend via the startup packet

### DIFF
--- a/src/postgres/src/backend/postmaster/postmaster.c
+++ b/src/postgres/src/backend/postmaster/postmaster.c
@@ -2489,6 +2489,15 @@ retry1:
 							 errhint("Value must be one of the registered "
 									 "YbInternalConnKind wire names.")));
 			}
+			else if (YBIsEnabledInPostgresEnvVar()
+					 && strcmp(nameptr, "yb_dist_traceparent") == 0)
+			{
+				/*
+				 * Stash traceparent for InitPostgres's backend-init span;
+				 * consumed here, turned into a corresponding GUC.
+				 */
+				port->yb_dist_traceparent = pstrdup(valptr);
+			}
 			else if (strncmp(nameptr, "_pq_.", 5) == 0)
 			{
 				/*

--- a/src/postgres/src/backend/utils/init/postinit.c
+++ b/src/postgres/src/backend/utils/init/postinit.c
@@ -1130,6 +1130,18 @@ InitPostgresImpl(const char *in_dbname, Oid dboid,
 	/* Connect to YugaByte cluster. */
 	YBInitPostgresBackend("postgres", yb_init_info);
 
+	if (IsYugaByteEnabled() && !bootstrap && MyProcPort != NULL &&
+		MyProcPort->yb_dist_traceparent != NULL &&
+		MyProcPort->yb_dist_traceparent[0] != '\0')
+	{
+		char		tracecontext[128];
+
+		snprintf(tracecontext, sizeof(tracecontext), "traceparent='%s'",
+				 MyProcPort->yb_dist_traceparent);
+		SetConfigOption("yb_dist_tracecontext", tracecontext,
+						PGC_BACKEND, PGC_S_CLIENT);
+	}
+
 	if (IsYugaByteEnabled() && !bootstrap)
 	{
 		HandleYBStatus(YBCPgTableExists(Template1DbOid,

--- a/src/postgres/src/include/libpq/libpq-be.h
+++ b/src/postgres/src/include/libpq/libpq-be.h
@@ -188,6 +188,13 @@ typedef struct Port
 	bool		yb_is_ssl_enabled_in_logical_conn;
 
 	/*
+	 * YB: W3C traceparent from the "yb_dist_traceparent" startup-packet param
+	 * (set by the tserver). Root span for backend init; read in InitPostgres.
+	 * NULL when absent.
+	 */
+	char	   *yb_dist_traceparent;
+
+	/*
 	 * Authenticated identity.  The meaning of this identifier is dependent on
 	 * hba->auth_method; it is the identity (if any) that the user presented
 	 * during the authentication cycle, before they were assigned a database

--- a/src/postgres/src/interfaces/libpq/fe-connect.c
+++ b/src/postgres/src/interfaces/libpq/fe-connect.c
@@ -355,6 +355,14 @@ static const internalPQconninfoOption PQconninfoOptions[] = {
 		"YB-Internal-Conn-Kind", "", 32,
 	offsetof(struct pg_conn, yb_internal_conn_kind)},
 
+	/*
+	 * W3C traceparent set on any connection that carries a trace context, used
+	 * as the root span for backend init and queries.
+	 */
+	{"yb_dist_traceparent", NULL, NULL, NULL,
+		"YB-Dist-Traceparent", "", 64,
+	offsetof(struct pg_conn, yb_dist_traceparent)},
+
 	/* Terminating entry --- MUST BE LAST */
 	{NULL, NULL, NULL, NULL,
 	NULL, NULL, 0}
@@ -4193,6 +4201,8 @@ freePGconn(PGconn *conn)
 		free(conn->target_session_attrs);
 	if (conn->yb_internal_conn_kind)
 		free(conn->yb_internal_conn_kind);
+	if (conn->yb_dist_traceparent)
+		free(conn->yb_dist_traceparent);
 	termPQExpBuffer(&conn->errorMessage);
 	termPQExpBuffer(&conn->workBuffer);
 

--- a/src/postgres/src/interfaces/libpq/fe-protocol3.c
+++ b/src/postgres/src/interfaces/libpq/fe-protocol3.c
@@ -2239,6 +2239,9 @@ build_startup_packet(const PGconn *conn, char *packet,
 	if (conn->yb_internal_conn_kind && conn->yb_internal_conn_kind[0])
 		ADD_STARTUP_OPTION("yb_internal_conn_kind",
 						   conn->yb_internal_conn_kind);
+	if (conn->yb_dist_traceparent && conn->yb_dist_traceparent[0])
+		ADD_STARTUP_OPTION("yb_dist_traceparent",
+						   conn->yb_dist_traceparent);
 	if (conn->send_appname)
 	{
 		/* Use appname if present, otherwise use fallback */

--- a/src/postgres/src/interfaces/libpq/libpq-int.h
+++ b/src/postgres/src/interfaces/libpq/libpq-int.h
@@ -400,6 +400,9 @@ struct pg_conn
 										 * names (see yb_internal_conn.h);
 										 * NULL/empty for a regular client
 										 * connection */
+	char	   *yb_dist_traceparent;	/* W3C traceparent for the backend's
+										  root trace span and query tracing from
+										  tserver; NULL when not tracing */
 
 	/* Optional file to write trace info to */
 	FILE	   *Pfdebug;

--- a/src/yb/yql/pgwrapper/libpq_utils.cc
+++ b/src/yb/yql/pgwrapper/libpq_utils.cc
@@ -28,6 +28,7 @@
 #include "yb/gutil/endian.h"
 
 #include "yb/util/backoff_waiter.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/endian_util.h"
 #include "yb/util/enums.h"
 #include "yb/util/format.h"
@@ -139,6 +140,9 @@ std::string BuildConnectionString(const PGConnSettings& settings, bool mask_pass
   if (!settings.yb_internal_conn_kind.empty()) {
     result += Format(
         " yb_internal_conn_kind=$0", PqEscapeStringConn(settings.yb_internal_conn_kind));
+  }
+  if (!settings.traceparent.empty()) {
+    result += Format(" yb_dist_traceparent=$0", PqEscapeStringConn(settings.traceparent));
   }
   return result;
 }
@@ -1030,7 +1034,8 @@ PGConnBuilder CreateInternalPGConnBuilder(
        .password = UInt64ToString(postgres_auth_key),
        .connect_timeout = connect_timeout,
        .yb_internal_conn_kind = std::string(yb_internal_conn_kind),
-       .should_stop = std::move(should_stop)});
+       .should_stop = std::move(should_stop),
+       .traceparent = dist_trace::GetActiveTraceparent()});
 }
 
 } // namespace yb::pgwrapper

--- a/src/yb/yql/pgwrapper/libpq_utils.h
+++ b/src/yb/yql/pgwrapper/libpq_utils.h
@@ -468,6 +468,9 @@ struct PGConnSettings {
   // shutting down). Checked between connection attempts, not during one. Carried by the builder, so
   // it also applies to any later reconnect made from a stored builder.
   std::function<bool()> should_stop = {};
+  // W3C traceparent for the distributed-trace root span the backend should
+  // activate intializing connection.
+  std::string traceparent = {};
 };
 
 class PGConnBuilder {


### PR DESCRIPTION
Carry a W3C traceparent from the tserver into the PG backend over the
connection startup packet, so the backend's init (and subsequent queries)
root under the originating trace. The tserver-side connection already has
an active trace context; this threads it to the backend.

libpq client (fe-connect.c, fe-protocol3.c, libpq-int.h):
- new yb_dist_traceparent conninfo option on pg_conn, freed with the conn,
  emitted as a startup-packet option when set.

libpq_utils (.cc/.h):
- PGConnSettings gains a traceparent field; BuildConnectionString appends
  yb_dist_traceparent; internal connections populate it from
  dist_trace::GetActiveTraceparent().

backend (postmaster.c, postinit.c, libpq-be.h):
- postmaster parses the yb_dist_traceparent startup param into
  Port::yb_dist_traceparent;
- InitPostgres turns it into the pre-existing yb_dist_tracecontext GUC
  (traceparent='...') so backend init activates that root span.

