### PR TITLE
[#16670] dist-trace: end-to-end distributed-tracing tests

### DIFF
--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -39,7 +39,6 @@
 #include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/format.h"
-#include "yb/util/flags.h"
 #include "yb/util/logging_test_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/random_util.h"
@@ -71,7 +70,7 @@ static constexpr auto kOtelBatchMaxQueueSize = 4096;
 static constexpr auto kOtelBatchMaxExportBatchSize = 512;
 static constexpr auto kOtelBatchScheduleDelayMs = 100;
 static constexpr auto kSharedMemoryPerformSpanName =
-    "shmem req yb.tserver.PgClientService.Perform";
+    "shmem yb.tserver.PgClientService.Perform";
 
 YB_DEFINE_ENUM(QueryExecMode, (kFetch)(kExecute));
 YB_STRONGLY_TYPED_BOOL(IsUtility);
@@ -190,7 +189,7 @@ class OtlpHttpCollector {
 
   static bool ShouldIgnoreForQuerySpanComparison(const Span& span) {
     return kExecutorNodeSpanNames.contains(span.op_name) ||
-           span.op_name.starts_with("shmem req ") ||
+           span.op_name.starts_with("shmem ") ||
            span.op_name.starts_with("rpc ");
   }
 
@@ -349,7 +348,8 @@ class OtlpHttpCollector {
     std::lock_guard lock(mutex_);
     for (const auto& [_, trace] : traces_) {
       for (const auto& span : trace.spans) {
-        if (span.op_name.starts_with(prefix) && span.status_message == status_message) {
+        if (span.op_name.starts_with(prefix) &&
+            span.status_message.find(status_message) != std::string_view::npos) {
           return true;
         }
       }
@@ -486,6 +486,49 @@ class OtlpHttpCollector {
         Format("Child spans of '$0' in trace '$1'", parent_op_name, trace_id));
   }
 
+  // Waits for a cross-boundary pairing in trace_id: a server span (service_name == server_service,
+  // op name starting with op_prefix, rpc.system == expected_rpc_system) whose parent_span_id is the
+  // span_id of a client span (service_name == client_service, same op_prefix). This proves the
+  // query's trace propagated from caller to callee. Returns the server span on success.
+  Result<Span> WaitForRemoteChildSpan(
+      std::string_view trace_id, std::string_view op_prefix,
+      std::string_view client_service, std::string_view server_service,
+      std::string_view expected_rpc_system) const EXCLUDES(mutex_) {
+    Span server_span;
+    RETURN_NOT_OK(WaitFor(
+        [&]() -> Result<bool> {
+          std::lock_guard lock(mutex_);
+          auto it = traces_.find(std::string(trace_id));
+          if (it == traces_.end()) return false;
+          const auto& spans = it->second.spans;
+          for (const auto& server : spans) {
+            if (server.service_name != server_service ||
+                !server.op_name.starts_with(op_prefix) ||
+                server.parent_span_id.empty()) {
+              continue;
+            }
+            auto sys_it = server.str_attrs.find("rpc.system");
+            if (sys_it == server.str_attrs.end() || sys_it->second != expected_rpc_system) {
+              continue;
+            }
+            // The server span's parent must be a client span in the same trace.
+            for (const auto& client : spans) {
+              if (client.service_name == client_service &&
+                  client.op_name.starts_with(op_prefix) &&
+                  client.span_id == server.parent_span_id) {
+                server_span = server;
+                return true;
+              }
+            }
+          }
+          return false;
+        },
+        kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+        Format("Remote child span '$0*' on '$1' linked to '$2' in trace '$3'",
+               op_prefix, server_service, client_service, trace_id)));
+    return server_span;
+  }
+
  private:
   void HandleTraceRequest(const Webserver::WebRequest& req, Webserver::WebResponse* resp) {
     if (req.request_method != "POST") {
@@ -585,16 +628,16 @@ class DistTraceTest : public LibPqTestBase {
   }
 
   virtual void ConfigureDistTraceOptions(ExternalMiniClusterOptions* options) {
-    AppendFlagToAllowedPreviewFlagsCsv(options->extra_tserver_flags,
-        "otel_collector_traces_endpoint");
-    options->extra_tserver_flags.push_back(
-        Format("--otel_collector_traces_endpoint=$0", collector_.Url()));
-    options->extra_tserver_flags.push_back(
-        Format("--otel_batch_schedule_delay_ms=$0", kOtelBatchScheduleDelayMs));
-    options->extra_tserver_flags.push_back(
-        Format("--otel_batch_max_export_batch_size=$0", kOtelBatchMaxExportBatchSize));
-    options->extra_tserver_flags.push_back(
-        Format("--otel_batch_max_queue_size=$0", kOtelBatchMaxQueueSize));
+    // Export OTEL traces from both tservers and masters so cross-boundary DDL spans (which land on
+    // the master) reach the collector.
+    for (auto* flags : {&options->extra_tserver_flags, &options->extra_master_flags}) {
+      AppendFlagToAllowedPreviewFlagsCsv(*flags, "otel_collector_traces_endpoint");
+      flags->push_back(Format("--otel_collector_traces_endpoint=$0", collector_.Url()));
+      flags->push_back(Format("--otel_batch_schedule_delay_ms=$0", kOtelBatchScheduleDelayMs));
+      flags->push_back(
+          Format("--otel_batch_max_export_batch_size=$0", kOtelBatchMaxExportBatchSize));
+      flags->push_back(Format("--otel_batch_max_queue_size=$0", kOtelBatchMaxQueueSize));
+    }
   }
 
   int GetNumTabletServers() const override {
@@ -1662,6 +1705,63 @@ TEST_F(DistTraceRpcTest, TestRpcSpans) {
       "RPC span to appear in trace"));
 }
 
+// Cross-boundary: the Perform RPC's trace must reach the tserver. The inbound server span on
+// TabletServer should be a child of the PG backend's (ysql) outbound client span.
+TEST_F(DistTraceRpcTest, TestRpcSpanReachesTabletServer) {
+  ASSERT_OK(CreateTable("rpc_crossing_test", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM rpc_crossing_test"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "rpc yb.tserver.PgClientService.Perform",
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_rpc" /* expected_rpc_system */));
+
+  ASSERT_EQ(server_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(server_span.str_attrs["rpc.method"], "Perform");
+}
+
+// Cross-boundary over shared memory: the Perform shmem exchange's trace must reach the tserver.
+// The inbound server span on TabletServer should be a child of the ysql outbound client span.
+TEST_F(DistTraceTest, TestSharedMemoryPerformReachesTabletServer) {
+  ASSERT_OK(CreateTable("shmem_crossing_test", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM shmem_crossing_test"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "shmem yb.tserver.PgClientService.Perform",
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_shmem" /* expected_rpc_system */));
+
+  ASSERT_EQ(server_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(server_span.str_attrs["rpc.method"], "Perform");
+}
+
+// Cross-boundary to master: a DDL fans out from the tserver to the master. A master inbound RPC
+// span should join the query's trace as a child of a tserver outbound span -- proving the trace
+// propagated the full PG -> tserver -> master chain. Any master method suffices, so match on the
+// "rpc " prefix and distinguish the boundary by service_name (TabletServer -> Master).
+TEST_F(DistTraceTest, TestDdlRpcReachesMaster) {
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Execute(
+      "CREATE TABLE master_crossing_test (id int PRIMARY KEY, val text)"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "rpc ",
+      "TabletServer" /* client_service */, "Master" /* server_service */,
+      "inbound_rpc" /* expected_rpc_system */));
+
+  ASSERT_STR_CONTAINS(server_span.str_attrs["rpc.service"], "yb.master.");
+}
+
 TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
   google::FlagSaver flag_saver;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
@@ -1815,7 +1915,8 @@ TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {
   ASSERT_OK(WaitFor(
       [&]() -> Result<bool> {
         return collector_.HasSpanWithNamePrefixAndStatusMessage(
-            "rpc WrongServiceName.ThisMethodDoesNotExist", "Call ErroredOut");
+            "rpc WrongServiceName.ThisMethodDoesNotExist",
+            "Service WrongServiceName not registered on TabletServer");
       },
       kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
       "Errored RPC span to appear in trace"));
@@ -1844,7 +1945,7 @@ TEST_F(DistTraceRpcTimeoutTest, TestTimedOutRpcSpanStatus) {
         auto rpc_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "rpc ");
         return std::any_of(rpc_spans.begin(), rpc_spans.end(), [](const Span& span) {
           return span.op_name.starts_with("rpc yb.tserver.PgClientService.GetLockStatus") &&
-                 span.status_message == "Call TimedOut";
+                 span.status_message.find("timed out after") != std::string::npos;
         });
       },
       kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,


### PR DESCRIPTION
pgwrapper/dist_trace-test.cc exercises the full propagation path across
the layers in this stack -- process init, RPC header and shared-memory
context propagation, span parent/child nesting, and startup-packet
traceparent -- asserting the expected trace/span relationships end to end.

