### PR TITLE
[#33506] DocDB: Start tablet flush when a snapshot create operation is prepared

### DIFF
--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -1422,7 +1422,10 @@ void Tablet::RegularDbFilesChanged() {
 
 void Tablet::SetCleanupPool(
     ThreadPool* snapshot_cleanup_pool, rpc::Scheduler* scheduler, ThreadPool* intent_cleanup_pool) {
-  snapshots_->SetCleanupPool(snapshot_cleanup_pool, scheduler);
+  // intent_cleanup_pool is the unbounded raft pool; it doubles as the snapshot preflush pool
+  // because the bounded snapshot cleanup pool can be fully occupied by recursive deletions,
+  // which would starve the preflush until after the snapshot operation has already applied.
+  snapshots_->SetCleanupPool(snapshot_cleanup_pool, scheduler, intent_cleanup_pool);
 
   if (!transaction_participant_) {
     return;

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -34,6 +34,7 @@
 #include "yb/tserver/backup.pb.h"
 
 #include "yb/util/backoff_waiter.h"
+#include "yb/util/countdown_latch.h"
 #include "yb/util/env.h"
 #include "yb/util/format.h"
 #include "yb/util/metrics.h"
@@ -209,6 +210,11 @@ class TabletSnapshotsTest : public YBTest {
     ASSERT_OK(ThreadPoolBuilder("snapshot-cleanup-test")
                   .set_max_threads(kCleanupThreadPoolSize)
                   .Build(&cleanup_pool_));
+    // Mirrors production, where the preflush runs on the unbounded raft pool rather than the
+    // bounded cleanup pool.
+    ASSERT_OK(ThreadPoolBuilder("snapshot-preflush-test")
+                  .unlimited_threads()
+                  .Build(&preflush_pool_));
   }
 
   void TearDown() override {
@@ -219,6 +225,7 @@ class TabletSnapshotsTest : public YBTest {
       harness_.reset();
     }
     cleanup_pool_->Shutdown();
+    preflush_pool_->Shutdown();
     messenger_->Shutdown();
     YBTest::TearDown();
   }
@@ -230,7 +237,8 @@ class TabletSnapshotsTest : public YBTest {
   };
 
   void InstallCleanupPool() {
-    harness_->tablet()->snapshots().SetCleanupPool(cleanup_pool_.get(), &messenger_->scheduler());
+    harness_->tablet()->snapshots().SetCleanupPool(
+        cleanup_pool_.get(), &messenger_->scheduler(), preflush_pool_.get());
   }
 
   SnapshotPaths CreateSnapshotDirectory(const std::string& snapshot_id, int64_t op_index) {
@@ -291,6 +299,7 @@ class TabletSnapshotsTest : public YBTest {
   Schema schema_;
   std::unique_ptr<SnapshotCleanupTestEnv> test_env_;
   std::unique_ptr<ThreadPool> cleanup_pool_;
+  std::unique_ptr<ThreadPool> preflush_pool_;
   std::unique_ptr<rpc::Messenger> messenger_;
   std::unique_ptr<TabletTestHarness> harness_;
 };
@@ -494,7 +503,7 @@ TEST_F(TabletSnapshotsTest, SharedPoolBoundsCleanupConcurrency) {
     ASSERT_OK(tablet_harness->Create(/* first_time = */ true));
     ASSERT_OK(tablet_harness->Open());
     tablet_harness->tablet()->snapshots().SetCleanupPool(
-        cleanup_pool_.get(), &messenger_->scheduler());
+        cleanup_pool_.get(), &messenger_->scheduler(), preflush_pool_.get());
 
     const auto snapshot_id = Format("snapshot-$0", i);
     const auto active =
@@ -599,7 +608,8 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
 }
 
 TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
-  // Exercise the production path: the flush scheduling call is dispatched to the cleanup pool.
+  // Exercise the dispatch path used once pools are installed. Note this calls
+  // TabletSnapshots::Prepare directly rather than going through the operation lifecycle.
   InstallCleanupPool();
 
   ASSERT_OK(WriteRow(1));
@@ -619,6 +629,34 @@ TEST_F(TabletSnapshotsTest, PrepareFlushesTabletWithoutCleanupPool) {
   ASSERT_OK(WriteRow(1));
   ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
+  ASSERT_OK(WaitFor(
+      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
+}
+
+TEST_F(TabletSnapshotsTest, PreflushNotStarvedByCleanupPool) {
+  InstallCleanupPool();
+
+  // Occupy every cleanup pool worker: one with a blocked recursive snapshot deletion, the rest
+  // with tasks parked on a latch. The preflush must still run because it lives on its own pool.
+  test_env_->BlockDeletes();
+  CreateSnapshotDirectory("snapshot.starve", 1);
+  ASSERT_OK(DeleteSnapshot("snapshot.starve", 1));
+  ASSERT_OK(WaitFor(
+      [this] { return test_env_->active_deletes() == 1; }, 10s,
+      "Wait for blocked snapshot cleanup"));
+
+  CountDownLatch latch(1);
+  auto release = ScopeExit([this, &latch] {
+    latch.CountDown();
+    test_env_->ReleaseDeletes();
+  });
+  for (int i = 0; i < kCleanupThreadPoolSize - 1; ++i) {
+    ASSERT_OK(cleanup_pool_->SubmitFunc([&latch] { latch.Wait(); }));
+  }
+
+  ASSERT_OK(WriteRow(1));
   ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
 
   ASSERT_OK(WaitFor(

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -19,10 +19,12 @@
 
 #include <gtest/gtest.h>
 
+#include "yb/common/ql_protocol_util.h"
 #include "yb/common/wire_protocol-test-util.h"
 
 #include "yb/rpc/messenger.h"
 
+#include "yb/tablet/local_tablet_writer.h"
 #include "yb/tablet/operations/snapshot_operation.h"
 #include "yb/tablet/tablet-test-harness.h"
 #include "yb/tablet/tablet-test-util.h"
@@ -42,6 +44,7 @@
 #include "yb/util/threadpool.h"
 
 DECLARE_bool(enable_async_snapshot_directory_cleanup);
+DECLARE_bool(snapshot_create_flush_on_prepare);
 DECLARE_int32(TEST_snapshot_cleanup_retry_delay_ms);
 
 METRIC_DECLARE_counter(snapshot_cleanup_failures);
@@ -189,6 +192,8 @@ class TabletSnapshotsTest : public YBTest {
     YBTest::SetUp();
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_async_snapshot_directory_cleanup) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_snapshot_cleanup_retry_delay_ms) = 10;
+    // Tests below toggle this flag; restore the default for each test in this process.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_on_prepare) = true;
 
     schema_ = GetSimpleTestSchema();
     schema_.InitColumnIdsByDefault();
@@ -249,6 +254,27 @@ class TabletSnapshotsTest : public YBTest {
     return harness_->tablet()->snapshots().Delete(operation);
   }
 
+  Status WriteRow(int32_t key) {
+    LocalTabletWriter writer(harness_->tablet());
+    QLWriteRequestPB req;
+    QLAddInt32HashValue(&req, key);
+    QLAddInt32ColumnValue(&req, kFirstColumnId + 1, key);
+    QLAddStringColumnValue(&req, kFirstColumnId + 2, "value");
+    return writer.Write(&req);
+  }
+
+  Status PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::Operation op_type) {
+    tserver::TabletSnapshotOpRequestPB request;
+    request.set_operation(op_type);
+    SnapshotOperation operation(harness_->tablet());
+    operation.AllocateRequest()->CopyFrom(request);
+    return harness_->tablet()->snapshots().Prepare(&operation);
+  }
+
+  uint64_t NumRegularDbSSTFiles() {
+    return harness_->tablet()->GetCurrentVersionNumSSTFiles();
+  }
+
   template <class Metric, class Prototype>
   uint64_t MetricValue(const Prototype& prototype) {
     return harness_->tablet()->GetTabletMetricsEntity()->FindOrNull<Metric>(prototype)->value();
@@ -271,6 +297,10 @@ class TabletSnapshotsTest : public YBTest {
 
 TEST(TabletSnapshotPathTest, AsyncCleanupDisabledByDefault) {
   ASSERT_FALSE(FLAGS_enable_async_snapshot_directory_cleanup);
+}
+
+TEST(TabletSnapshotPathTest, FlushOnPrepareEnabledByDefault) {
+  ASSERT_TRUE(FLAGS_snapshot_create_flush_on_prepare);
 }
 
 TEST(TabletSnapshotPathTest, DeletedSnapshotDirectoryName) {
@@ -566,6 +596,38 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
   shutdown_thread.JoinAll();
   ASSERT_TRUE(shutdown_complete.load(std::memory_order_acquire));
   ASSERT_FALSE(test_env_->FileExists(paths.tombstone));
+}
+
+TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
+  ASSERT_OK(WriteRow(1));
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
+
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
+  // The prepare-time flush is asynchronous; it must eventually push the memtable into an SST
+  // without any further nudge.
+  ASSERT_OK(WaitFor(
+      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
+}
+
+TEST_F(TabletSnapshotsTest, PrepareDoesNotFlushWhenDisabled) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_on_prepare) = false;
+
+  ASSERT_OK(WriteRow(1));
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
+  // A wrongly scheduled async flush of a single row would complete well within this window.
+  SleepFor(200ms);
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
+}
+
+TEST_F(TabletSnapshotsTest, PrepareDoesNotFlushForNonCreateOperations) {
+  ASSERT_OK(WriteRow(1));
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::DELETE_ON_TABLET));
+
+  // A wrongly scheduled async flush of a single row would complete well within this window.
+  SleepFor(200ms);
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 }
 
 }  // namespace

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -599,6 +599,9 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
 }
 
 TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
+  // Exercise the production path: the flush scheduling call is dispatched to the cleanup pool.
+  InstallCleanupPool();
+
   ASSERT_OK(WriteRow(1));
   ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 
@@ -606,6 +609,18 @@ TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
 
   // The prepare-time flush is asynchronous; it must eventually push the memtable into an SST
   // without any further nudge.
+  ASSERT_OK(WaitFor(
+      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
+}
+
+TEST_F(TabletSnapshotsTest, PrepareFlushesTabletWithoutCleanupPool) {
+  // Without an installed pool (before InitTabletPeer, or in tests) the preflush falls back to
+  // scheduling the flush inline.
+  ASSERT_OK(WriteRow(1));
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
+
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
   ASSERT_OK(WaitFor(
       [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
 }

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -229,7 +229,8 @@ TabletSnapshots::~TabletSnapshots() {
   CompleteShutdown();
 }
 
-void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* scheduler) {
+void TabletSnapshots::SetCleanupPool(
+    ThreadPool* thread_pool, rpc::Scheduler* scheduler, ThreadPool* preflush_pool) {
   {
     std::lock_guard lock(cleanup_mutex_);
     if (shutting_down_) {
@@ -237,7 +238,9 @@ void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* sc
     }
     DCHECK(!cleanup_token_);
     cleanup_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::SERIAL);
-    preflush_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
+    if (preflush_pool) {
+      preflush_token_ = preflush_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
+    }
     retry_task_tracker_.Bind(scheduler);
   }
 
@@ -397,7 +400,7 @@ void TabletSnapshots::SubmitPreflush() {
   // On the leader, Prepare runs on the preparer thread, but on followers it runs inline in
   // UpdateConsensus while the ReplicaState lock is held (see PreparerImpl::Submit). Even a
   // non-waiting Tablet::Flush call synchronously enters the RocksDB write queue to switch the
-  // memtable, so dispatch it to the cleanup pool instead of running it here. The token is
+  // memtable, so dispatch it to the preflush pool instead of running it here. The token is
   // shut down in CompleteShutdown, so the task cannot outlive this object.
   {
     std::lock_guard lock(cleanup_mutex_);
@@ -405,19 +408,22 @@ void TabletSnapshots::SubmitPreflush() {
       return;
     }
     if (preflush_token_) {
-      const Status submit_status = preflush_token_->SubmitFunc([this] {
-        WARN_NOT_OK(
-            Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
-            LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
-      });
-      if (PREDICT_TRUE(submit_status.ok())) {
-        return;
-      }
-      LOG_WITH_PREFIX(WARNING) << "Cannot submit snapshot preflush task: " << submit_status;
+      // A submission failure means the token or pool is shutting down; drop the best-effort
+      // preflush rather than flushing inline, which would reintroduce the consensus-path work.
+      WARN_NOT_OK(
+          preflush_token_->SubmitFunc([this] {
+            WARN_NOT_OK(
+                Flush(
+                    FlushMode::kAsync, FlushFlags::kAllDbs,
+                    rocksdb::FlushReason::kSnapshotCreation),
+                LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+          }),
+          LogPrefix() + "Cannot submit snapshot preflush task");
+      return;
     }
   }
-  // No pool installed (or submission failed): flush inline. This only happens before
-  // SetCleanupPool is called, i.e. before the tablet serves consensus traffic, and in tests.
+  // No preflush pool installed: flush inline. This only happens before SetCleanupPool is called,
+  // i.e. before the tablet serves consensus traffic, and in tests.
   WARN_NOT_OK(
       Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
       LogPrefix() + "Failed to schedule flush while preparing snapshot creation");

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -237,6 +237,7 @@ void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* sc
     }
     DCHECK(!cleanup_token_);
     cleanup_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::SERIAL);
+    preflush_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
     retry_task_tracker_.Bind(scheduler);
   }
 
@@ -255,6 +256,7 @@ void TabletSnapshots::StartShutdown() {
 
 void TabletSnapshots::CompleteShutdown() {
   std::unique_ptr<ThreadPoolToken> cleanup_token;
+  std::unique_ptr<ThreadPoolToken> preflush_token;
   {
     std::lock_guard lock(cleanup_mutex_);
     if (!shutting_down_) {
@@ -266,9 +268,13 @@ void TabletSnapshots::CompleteShutdown() {
   {
     std::lock_guard lock(cleanup_mutex_);
     cleanup_token = std::move(cleanup_token_);
+    preflush_token = std::move(preflush_token_);
   }
   if (cleanup_token) {
     cleanup_token->Shutdown();
+  }
+  if (preflush_token) {
+    preflush_token->Shutdown();
   }
   {
     std::lock_guard lock(cleanup_mutex_);
@@ -376,16 +382,45 @@ bool TabletSnapshots::IsLastSnapshotTimeFilePath(const std::string& dir) {
 Status TabletSnapshots::Prepare(SnapshotOperation* operation) {
   if (FLAGS_snapshot_create_flush_on_prepare &&
       operation->operation() == tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET) {
-    // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
-    // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
-    // operation on this tablet; warming the flush here shrinks that window to the delta written
-    // between prepare and apply. Correctness does not depend on this flush happening or
-    // completing: Create() still flushes synchronously before creating the checkpoint.
-    WARN_NOT_OK(
-        Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
-        LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+    SubmitPreflush();
   }
   return Status::OK();
+}
+
+void TabletSnapshots::SubmitPreflush() {
+  // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
+  // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
+  // operation on this tablet; warming the flush here shrinks that window to the delta written
+  // between prepare and apply. Correctness does not depend on this flush happening or completing:
+  // Create() still flushes synchronously before creating the checkpoint.
+  //
+  // On the leader, Prepare runs on the preparer thread, but on followers it runs inline in
+  // UpdateConsensus while the ReplicaState lock is held (see PreparerImpl::Submit). Even a
+  // non-waiting Tablet::Flush call synchronously enters the RocksDB write queue to switch the
+  // memtable, so dispatch it to the cleanup pool instead of running it here. The token is
+  // shut down in CompleteShutdown, so the task cannot outlive this object.
+  {
+    std::lock_guard lock(cleanup_mutex_);
+    if (shutting_down_) {
+      return;
+    }
+    if (preflush_token_) {
+      const Status submit_status = preflush_token_->SubmitFunc([this] {
+        WARN_NOT_OK(
+            Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
+            LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+      });
+      if (PREDICT_TRUE(submit_status.ok())) {
+        return;
+      }
+      LOG_WITH_PREFIX(WARNING) << "Cannot submit snapshot preflush task: " << submit_status;
+    }
+  }
+  // No pool installed (or submission failed): flush inline. This only happens before
+  // SetCleanupPool is called, i.e. before the tablet serves consensus traffic, and in tests.
+  WARN_NOT_OK(
+      Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
+      LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
 }
 
 Status TabletSnapshots::Create(SnapshotOperation* operation) {

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -69,6 +69,12 @@ DEFINE_NON_RUNTIME_int32(snapshot_cleanup_pool_size, 4,
     "Maximum number of concurrent tablet snapshot directory cleanup tasks per process.");
 TAG_FLAG(snapshot_cleanup_pool_size, advanced);
 
+DEFINE_RUNTIME_bool(snapshot_create_flush_on_prepare, true,
+    "Start a non-blocking flush of the tablet when a snapshot create operation is prepared, "
+    "so that most memtable data is already on disk by the time the operation is applied. "
+    "The synchronous flush during apply remains as the correctness backstop.");
+TAG_FLAG(snapshot_create_flush_on_prepare, advanced);
+
 DEFINE_test_flag(int32, delay_tablet_split_metadata_restore_secs, 0,
     "How much time in secs to delay restoring tablet split metadata after restoring "
     "checkpoint.");
@@ -368,6 +374,17 @@ bool TabletSnapshots::IsLastSnapshotTimeFilePath(const std::string& dir) {
 }
 
 Status TabletSnapshots::Prepare(SnapshotOperation* operation) {
+  if (FLAGS_snapshot_create_flush_on_prepare &&
+      operation->operation() == tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET) {
+    // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
+    // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
+    // operation on this tablet; warming the flush here shrinks that window to the delta written
+    // between prepare and apply. Correctness does not depend on this flush happening or
+    // completing: Create() still flushes synchronously before creating the checkpoint.
+    WARN_NOT_OK(
+        Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
+        LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+  }
   return Status::OK();
 }
 
@@ -395,7 +412,11 @@ Status TabletSnapshots::Create(const CreateSnapshotData& data) {
   Status s;
   {
     SCOPED_WAIT_STATUS(Snapshot_WaitingForFlush);
-    s = regular_db().Flush(rocksdb::FlushOptions(rocksdb::FlushReason::kSnapshotCreation));
+    // Flush all DBs, not just the regular DB, so the flushes triggered internally by checkpoint
+    // creation below become no-ops; the intents flush would otherwise run while additionally
+    // holding create_checkpoint_lock(). When the prepare-time flush (see Prepare()) already ran,
+    // this only waits for the delta written since then.
+    s = Flush(FlushMode::kSync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation);
   }
 
   if (PREDICT_FALSE(!s.ok())) {

--- a/src/yb/tablet/tablet_snapshots.h
+++ b/src/yb/tablet/tablet_snapshots.h
@@ -71,7 +71,12 @@ class TabletSnapshots : public TabletComponent {
 
   Status Open();
 
-  void SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* scheduler);
+  // preflush_pool must not be starvable by long-running tasks (e.g. an unbounded pool): the
+  // prepare-time snapshot preflush is only useful if it starts before the operation is applied,
+  // and its token shutdown waits for queued tasks. May be null; then the preflush is scheduled
+  // inline from Prepare.
+  void SetCleanupPool(
+      ThreadPool* thread_pool, rpc::Scheduler* scheduler, ThreadPool* preflush_pool);
   void StartShutdown();
   void CompleteShutdown();
 
@@ -208,9 +213,9 @@ class TabletSnapshots : public TabletComponent {
   // without this mutex, and only the serial token may call RunCleanup.
   std::mutex cleanup_mutex_;
   std::unique_ptr<ThreadPoolToken> cleanup_token_ GUARDED_BY(cleanup_mutex_);
-  // Concurrent-mode token on the same pool as cleanup_token_, used to dispatch the best-effort
-  // prepare-time flush of snapshot creation. Kept separate from the serial cleanup token so the
-  // flush does not queue behind recursive snapshot directory deletions.
+  // Concurrent-mode token used to dispatch the best-effort prepare-time flush of snapshot
+  // creation. Lives on an unstarvable pool, not the bounded snapshot cleanup pool, so the flush
+  // cannot queue behind recursive snapshot directory deletions from any tablet.
   std::unique_ptr<ThreadPoolToken> preflush_token_ GUARDED_BY(cleanup_mutex_);
   std::unordered_map<std::string, PendingSnapshotDeletion> pending_deletions_
       GUARDED_BY(cleanup_mutex_);

--- a/src/yb/tablet/tablet_snapshots.h
+++ b/src/yb/tablet/tablet_snapshots.h
@@ -192,6 +192,7 @@ class TabletSnapshots : public TabletComponent {
   void ScanDeletedSnapshotDirs();
   void ScheduleCleanup(PendingSnapshotDeletion deletion);
   void SubmitCleanup();
+  void SubmitPreflush();
   void RunCleanup();
   void ScheduleRetry();
   void PublishPendingDeletionState(const PendingSnapshotDeletion& deletion);
@@ -207,6 +208,10 @@ class TabletSnapshots : public TabletComponent {
   // without this mutex, and only the serial token may call RunCleanup.
   std::mutex cleanup_mutex_;
   std::unique_ptr<ThreadPoolToken> cleanup_token_ GUARDED_BY(cleanup_mutex_);
+  // Concurrent-mode token on the same pool as cleanup_token_, used to dispatch the best-effort
+  // prepare-time flush of snapshot creation. Kept separate from the serial cleanup token so the
+  // flush does not queue behind recursive snapshot directory deletions.
+  std::unique_ptr<ThreadPoolToken> preflush_token_ GUARDED_BY(cleanup_mutex_);
   std::unordered_map<std::string, PendingSnapshotDeletion> pending_deletions_
       GUARDED_BY(cleanup_mutex_);
   rpc::ScheduledTaskTracker retry_task_tracker_;


### PR DESCRIPTION
## Summary

`CREATE_ON_TABLET` snapshot operations are applied inline on the Raft apply path while the tablet's ReplicaState mutex is held. The synchronous RocksDB flush at the start of `TabletSnapshots::Create` is usually the longest part of that window on a write-heavy tablet: while it runs, every write, lease-checked read, and follower `UpdateConsensus` for the tablet blocks behind the mutex. Namespace-wide snapshots (backups, PITR schedules) hit every tablet at once, so one slow flush per tablet can escalate into node-wide latency spikes.

This PR starts the flush earlier so the apply-time flush only has to cover the delta:

- `TabletSnapshots::Prepare` now schedules a non-waiting flush of all DBs when a `CREATE_ON_TABLET` operation enters the pending queue, overlapping the flush with Raft replication. On followers, `Prepare` runs inline in `UpdateConsensus` under the ReplicaState lock (`PreparerImpl::Submit` invokes `PrepareAndStartTask` directly), and even a non-waiting `Tablet::Flush` synchronously enters the RocksDB write queue to switch the memtable -- so the scheduling call is dispatched to the unbounded raft pool (already handed to `Tablet::SetCleanupPool` for intent file cleanup) via a concurrent token that is shut down with the tablet. The bounded snapshot cleanup pool is deliberately not used: its `snapshot_cleanup_pool_size` (4) process-wide workers can be fully occupied by recursive snapshot deletions, which would starve the preflush until after apply and couple tablet shutdown to other tablets' cleanup work.
- The apply-time flush in `Create` is widened from the regular DB to `FlushFlags::kAllDbs`, so the intents flush no longer runs inside checkpoint creation while additionally holding `create_checkpoint_lock()`, where it contends with remote bootstrap checkpoints.

Correctness does not depend on the prepare-time flush happening or completing: the synchronous flush during apply remains the backstop, and the checkpoint's hybrid-time filter continues to define transactional snapshot content. The preflush is best-effort -- dropped on executor shutdown, and scheduled inline when no pool is installed yet (before `InitTabletPeer`, i.e. before the tablet serves consensus traffic).

Guarded by the new runtime flag `snapshot_create_flush_on_prepare` (default: true).

## Upgrade/Rollback safety

No wire-format, on-disk-format, or catalog changes. The new gflag `snapshot_create_flush_on_prepare` is runtime-settable and defaults to true; it changes only *when* a RocksDB flush is scheduled, not what data a snapshot contains (each replica's checkpoint has always been a superset trimmed by the hybrid-time filter, and the apply-time flush backstop is unchanged). Behavior is node-local, so mixed-version clusters are unaffected. Rollback: set the flag to false at runtime or downgrade the binary -- no persistent state depends on it.

## Test plan

All run locally (release, clang21, arm64), one test per execution:

- [x] New: `TabletSnapshotsTest.PrepareFlushesTabletForSnapshotCreation` (pool dispatch path)
- [x] New: `TabletSnapshotsTest.PrepareFlushesTabletWithoutCleanupPool` (inline fallback)
- [x] New: `TabletSnapshotsTest.PreflushNotStarvedByCleanupPool` (every cleanup-pool worker blocked by deletions; preflush still runs)
- [x] New: `TabletSnapshotsTest.PrepareDoesNotFlushWhenDisabled`
- [x] New: `TabletSnapshotsTest.PrepareDoesNotFlushForNonCreateOperations`
- [x] New: `TabletSnapshotPathTest.FlushOnPrepareEnabledByDefault`
- [x] Regression: `TabletSnapshotsTest.ShutdownWaitsForRunningCleanup`, `SharedPoolBoundsCleanupConcurrency`, `RetainsDeletionUntilCleanupPoolIsInstalled`, `DeletesSynchronouslyWhenAsyncCleanupDisabled` (SetCleanupPool/CompleteShutdown changes)
- [x] Regression: `TestRaftGroupMetadata.TestDeleteTabletDataClearsDisk` (exercises the modified `Create` flush path)
